### PR TITLE
✨ Added Meta Key to Keybinds

### DIFF
--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -416,6 +416,9 @@ function replaceAcceleratorText(text) {
     if (text.indexOf('CmdOrCtrl') !== -1)
         if (isMac()) text = text.replace('CmdOrCtrl', 'Cmd')
         else text = text.replace('CmdOrCtrl', 'Ctrl')
+    
+    if (text.indexOf('Meta') !== -1 && isWindows())
+        text = text.replace('Meta', 'Windows')
 
     text = text.replace('numadd', '+')
 
@@ -460,6 +463,7 @@ function validateKey(e) {
 
 function preventSpecialKeys(e) {
     return !(
+        e.key === 'Meta' ||
         e.key === 'Command' ||
         e.key === 'Control' ||
         e.key === 'Alt' ||
@@ -478,6 +482,8 @@ document
         if (preventSpecialKeys(e)) {
             keyBindings = ''
 
+            if (e.metaKey) keyBindings += 'Meta+'
+            
             if (e.ctrlKey) keyBindings += 'CmdOrCtrl+'
 
             if (e.altKey) keyBindings += 'Alt+'


### PR DESCRIPTION
Adds Meta/Windows Key to be supported by Keybinds.

Prevents Meta/Windows key from being used on it's own.
Adds Meta key to be allowed from the Keybind.
Displays `Windows` instead of `Meta` on Windows Devices.
    *This maybe can be changed to display something else like Win or Windows Key*

Fixes: #725