### PR TITLE
Bump actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Github checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node (v18)
         uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Github checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node (v18)
         uses: actions/setup-node@v3


### PR DESCRIPTION
This PR bumps [actions/checkout](https://github.com/actions/checkout) in YTMD v2 workflows from 3 to 4.

<details>
<summary>Release notes</summary>

- https://github.com/actions/checkout/releases/tag/v4.0.0
- https://github.com/actions/checkout/releases/tag/v4.1.0

</details>