### PR TITLE
✨ Add basic support for chrome extensions

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1816,8 +1816,8 @@ app.on("ready", async () => {
   }
 
   // Load Chrome Extensions
-  log.info("Load chrome extensions");
-  loadChromeExtensions();
+  log.info("Loading chrome extensions");
+  await loadChromeExtensions();
 
   // Integrations setup
   log.info("Starting enabled integrations");


### PR DESCRIPTION
This PR adds an extension folder (```[app directory]/extensions```). You can paste unpacked extensions into it and the app will load them. Note that this is quite a barebones implementation as there isn't any UI yet so the user has to manually find the folder.

Also, the functionality in extensions only goes as far as electron supports it. You can read about which features aren't working yet [here](https://www.electronjs.org/docs/latest/api/extensions).