### PR TITLE
✨ Add change song command to API

### DIFF
--- a/src/main/integrations/companion-server/api-shared/errors.ts
+++ b/src/main/integrations/companion-server/api-shared/errors.ts
@@ -6,6 +6,7 @@ const errorCodes = [
   "INVALID_REPEAT_MODE",
   "INVALID_SEEK_POSITION",
   "INVALID_QUEUE_INDEX",
+  "INVALID_CHANGE_REQUEST",
   "UNAUTHENTICATED",
   "AUTHORIZATION_DISABLED",
   "AUTHORIZATION_INVALID",
@@ -21,6 +22,7 @@ export const InvalidVolumeError = createError<[number]>("INVALID_VOLUME", "Volum
 export const InvalidRepeatModeError = createError<[RepeatMode]>("INVALID_REPEAT_MODE", "Repeat mode '%s' cannot be set", 400);
 export const InvalidPositionError = createError<[number]>("INVALID_SEEK_POSITION", "Seek position '%s' is invalid", 400);
 export const InvalidQueueIndexError = createError<[number]>("INVALID_QUEUE_INDEX", "'%s' is an invalid queue index for the current queue", 400);
+export const InvalidChangeVideoRequestError = createError<[]>("INVALID_CHANGE_REQUEST", "'videoId', 'playlistId', or both must be provided", 400);
 export const UnauthenticatedError = createError<[]>("UNAUTHENTICATED", "Authentication not provided or invalid", 401);
 export const AuthorizationDisabledError = createError<[]>("AUTHORIZATION_DISABLED", "Authorization requests are disabled", 403);
 export const AuthorizationInvalidError = createError<[]>("AUTHORIZATION_INVALID", "Authorization invalid", 400);

--- a/src/main/integrations/companion-server/api-shared/schemas.ts
+++ b/src/main/integrations/companion-server/api-shared/schemas.ts
@@ -56,6 +56,13 @@ export const APIV1CommandRequestBody = Type.Union([
     })
   }),
   Type.Object({
+    command: Type.Literal("changeVideo"),
+    data: Type.Object({
+      videoId: Type.Optional(Type.String()),
+      playlistId: Type.Optional(Type.String())
+    })
+  }),
+  Type.Object({
     command: Type.Literal("toggleLike")
   }),
   Type.Object({

--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -23,6 +23,7 @@ import {
   InvalidPositionError,
   InvalidQueueIndexError,
   InvalidRepeatModeError,
+  InvalidChangeVideoRequestError,
   InvalidVolumeError,
   UnauthenticatedError,
   YouTubeMusicTimeOutError,
@@ -145,6 +146,21 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
             throw new InvalidPositionError(position);
           }
           ytmView.webContents.send("remoteControl:execute", "seekTo", position);
+          break;
+        }
+
+        case "changeVideo": {
+          const videoId = commandRequest.data.videoId;
+          const playlistId = commandRequest.data.playlistId;
+          if (videoId == null && playlistId == null) {
+            throw new InvalidChangeVideoRequestError();
+          }
+          ytmView.webContents.send("remoteControl:execute", "navigate", {
+            watchEndpoint: {
+              videoId: videoId,
+              playlistId: playlistId
+            }
+          });
           break;
         }
 


### PR DESCRIPTION
This just adds a command to the API to change the current song/playlist, using logic copied from the existing implementation for the URI handler. There's still useful functionality that won't be covered, such as adding a song to the queue without replacing the queue entirely, but this at least covers a major use case.

There's no validation to ensure the video and playlist id are correct, which can cause some weirdness; invalid playlist ids will cause the bottom bar to disappear, for example.