### PR TITLE
forge: flatpak build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,3 +53,4 @@ jobs:
             out/make/deb/${{ matrix.arch }}/*.deb
             out/make/rpm/${{ matrix.arch }}/*.rpm
             out/make/zip/darwin/${{ matrix.arch }}/*.zip
+            out/make/flatpak/${{ matrix.arch }}/*.flatpak

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ TODO: Fill this information in
 Building the project on Linux only requires you to install:
 - For building on Debian based Linux Distros like Ubuntu, you will need to install `fakeroot` and `dpkg`
 - For building on RedHat based Linux Distros like Fedora, you will need to install `rpm` or `rpm-build`
+- For building flatpak bundles, you need to install `flatpak`, `flatpak-builder`, and `eu-strip` (usually part of the `elfutils` package).
 
 *please note that by default both packages are built if you try building this application on a linux distro*
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -3,6 +3,7 @@ import { MakerSquirrel } from "@electron-forge/maker-squirrel";
 import { MakerZIP } from "@electron-forge/maker-zip";
 import { MakerDeb } from "@electron-forge/maker-deb";
 import { MakerRpm } from "@electron-forge/maker-rpm";
+import { MakerFlatpak } from "@electron-forge/maker-flatpak";
 import { WebpackPlugin } from "@electron-forge/plugin-webpack";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
 
@@ -63,6 +64,39 @@ const config: ForgeConfig = {
         mimeType: ["x-scheme-handler/ytmd"],
         section: "sound",
         icon: "./src/assets/icons/ytmd.png"
+      }
+    }),
+    new MakerFlatpak({
+      options: {
+        id: "app.ytmdesktop.ytmdesktop2",
+        files: [],
+        categories: ["AudioVideo", "Audio"],
+        mimeType: ["x-scheme-handler/ytmd"],
+        icon: "./src/assets/icons/ytmd.png",
+        baseVersion: "23.08",
+        runtimeVersion: "23.08",
+        modules: [
+          {
+            name: "zypak",
+            sources: [
+              {
+                type: "git",
+                url: "https://github.com/refi64/zypak",
+                tag: "v2024.01.17"
+              }
+            ]
+          }
+        ],
+        finishArgs: [
+          "--socket=pulseaudio",
+          "--socket=wayland",
+          "--socket=x11",
+          "--share=ipc",
+          "--share=network",
+          "--device=dri",
+          "--own-name=org.mpris.MediaPlayer2.youtubemusic",
+          "--filesystem=xdg-run/app/com.discordapp.Discord:create"
+        ]
       }
     })
   ],

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -88,14 +88,27 @@ const config: ForgeConfig = {
           }
         ],
         finishArgs: [
-          "--socket=pulseaudio",
-          "--socket=wayland",
+          // Rendering
           "--socket=x11",
+          "--socket=wayland",
           "--share=ipc",
-          "--share=network",
+          // OpenGL
           "--device=dri",
-          "--own-name=org.mpris.MediaPlayer2.youtubemusic",
-          "--filesystem=xdg-run/app/com.discordapp.Discord:create"
+          // Audio output
+          "--socket=pulseaudio",
+          // Read/write home directory access
+          "--filesystem=home",
+          // Chromium uses a socket in tmp for its singleton check
+          "--env=TMPDIR=/var/tmp",
+          // Allow communication with network
+          "--share=network",
+          // System notifications with libnotify
+          "--talk-name=org.freedesktop.Notifications",
+          // MPRIS (Chromium uses chromium.instance{PID})
+          "--own-name=org.mpris.MediaPlayer2.chromium.*",
+          // Discord Rich Presence
+          "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+          "--filesystem=xdg-run/discord-ipc-*"
         ]
       }
     })

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@electron-forge/cli": "~7.4.0",
     "@electron-forge/maker-deb": "~7.4.0",
+    "@electron-forge/maker-flatpak": "^7.4.0",
     "@electron-forge/maker-rpm": "~7.4.0",
     "@electron-forge/maker-squirrel": "~7.4.0",
     "@electron-forge/maker-zip": "~7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -183,6 +183,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@electron-forge/maker-flatpak@npm:^7.4.0":
+  version: 7.4.0
+  resolution: "@electron-forge/maker-flatpak@npm:7.4.0"
+  dependencies:
+    "@electron-forge/maker-base": "npm:7.4.0"
+    "@electron-forge/shared-types": "npm:7.4.0"
+    "@malept/electron-installer-flatpak": "npm:^0.11.4"
+    fs-extra: "npm:^10.0.0"
+  dependenciesMeta:
+    "@malept/electron-installer-flatpak":
+      optional: true
+  checksum: 10c0/095b9dc5fb8dad637739dbb864f9e9ea677889ea29cf7824d14b52f1e6cdd2d06f337ca3c96e0baa6173d4a3bc5888aa2a3d425e9128d217e0ee6e5c58b7c108
+  languageName: node
+  linkType: hard
+
 "@electron-forge/maker-rpm@npm:~7.4.0":
   version: 7.4.0
   resolution: "@electron-forge/maker-rpm@npm:7.4.0"
@@ -838,6 +853,34 @@ __metadata:
   dependencies:
     cross-spawn: "npm:^7.0.1"
   checksum: 10c0/84d60b8d467f4252114849f0a33c3763f07898335269eec5c94978ccac9d5680e1e268d993dd1a6d25a91476f9e0992759d7e1f385f9f3a090d862f9bb949603
+  languageName: node
+  linkType: hard
+
+"@malept/electron-installer-flatpak@npm:^0.11.4":
+  version: 0.11.4
+  resolution: "@malept/electron-installer-flatpak@npm:0.11.4"
+  dependencies:
+    "@malept/flatpak-bundler": "npm:^0.4.0"
+    debug: "npm:^4.1.1"
+    electron-installer-common: "npm:^0.10.0"
+    lodash: "npm:^4.17.15"
+    semver: "npm:^7.1.1"
+    yargs: "npm:^16.0.0"
+  bin:
+    electron-installer-flatpak: bin/electron-installer-flatpak.js
+  conditions: (os=darwin | os=linux)
+  languageName: node
+  linkType: hard
+
+"@malept/flatpak-bundler@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@malept/flatpak-bundler@npm:0.4.0"
+  dependencies:
+    debug: "npm:^4.1.1"
+    fs-extra: "npm:^9.0.0"
+    lodash: "npm:^4.17.15"
+    tmp-promise: "npm:^3.0.2"
+  checksum: 10c0/b3c87f6482b1956411af1118c771afb39cd9a0568fbb5e86015547ff6d68d2e73a7f0d74b75a57f0a156391c347c8d0adc1037e75172b92da72b96e0a05a2f4f
   languageName: node
   linkType: hard
 
@@ -3491,7 +3534,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-installer-common@npm:^0.10.2":
+"electron-installer-common@npm:^0.10.0, electron-installer-common@npm:^0.10.2":
   version: 0.10.3
   resolution: "electron-installer-common@npm:0.10.3"
   dependencies:
@@ -9927,7 +9970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^16.0.2":
+"yargs@npm:^16.0.0, yargs@npm:^16.0.2":
   version: 16.2.0
   resolution: "yargs@npm:16.2.0"
   dependencies:
@@ -10000,6 +10043,7 @@ __metadata:
   dependencies:
     "@electron-forge/cli": "npm:~7.4.0"
     "@electron-forge/maker-deb": "npm:~7.4.0"
+    "@electron-forge/maker-flatpak": "npm:^7.4.0"
     "@electron-forge/maker-rpm": "npm:~7.4.0"
     "@electron-forge/maker-squirrel": "npm:~7.4.0"
     "@electron-forge/maker-zip": "npm:~7.4.0"


### PR DESCRIPTION
This change add the generation of .flatpak files on `yarn make`

ToDo: 
- [ ] CI is missing make dependencies
- [ ] Integrations seem to be blocked by flatpak sandboxing