### PR TITLE
Refactor and Fix Log Hook in 'index.ts'

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -66,11 +66,11 @@ log.eventLogger.format = "Electron event {eventSource}#{eventName} observed";
 
 // Fix to https://github.com/ytmdesktop/ytmdesktop/issues/1394#issuecomment-2244147375 -aki6
 log.hooks.push((message, transport) => {
-  if (transport !== log.transports.file) return message;
+  if (transport !== log.transports.file) { return message; }
 
   const isSpamMessage = (data: any) => {
     return typeof data === 'string' && data.includes("Third-party cookie will be blocked.");
-  };
+  }
 
   if (message?.data?.[0] && isSpamMessage(message.data[0])) {
     return false;

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -64,7 +64,6 @@ log.transports.console.format = "[{processType}][{level}]{text}";
 log.transports.file.format = "[{y}-{m}-{d} {h}:{i}:{s}.{ms}][{processType}][{level}]{text}";
 log.eventLogger.format = "Electron event {eventSource}#{eventName} observed";
 
-// Fix to https://github.com/ytmdesktop/ytmdesktop/issues/1394#issuecomment-2244147375 -aki6
 log.hooks.push((message, transport) => {
   if (transport !== log.transports.file) { return message; }
 


### PR DESCRIPTION
This is a small fix/improvement to the existing Log Hook in 'index.ts'

The original code errored if message.data was not an array or contained non-string elements. The changes check the types to prevent errors from occurring.