### PR TITLE
💄 Improve consistency of title-bar (windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ scripts/CONTRIBUTORS.md
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# JetBrains IDE (could be more specific, but it's no issues at all, to just ignore the entire folder)
+.idea

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -147,6 +147,7 @@ if (props.isMainWindow) {
 .titlebar .right .app-buttons {
   display: flex;
   flex-direction: row;
+  margin-right: 16px;
 }
 
 .title {
@@ -184,8 +185,9 @@ if (props.isMainWindow) {
 }
 
 .app-button {
-  height: 35px;
-  width: 44px;
+  margin-right: 4px;
+  height: 28px;
+  width: 28px;
   background: none;
   color: #bbbbbb;
   display: flex;
@@ -193,7 +195,7 @@ if (props.isMainWindow) {
   justify-content: center;
   -webkit-app-region: no-drag;
   border: none;
-  border-radius: 0;
+  border-radius: 4px;
   font-variation-settings:
     "FILL" 0,
     "wght" 200,

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -166,6 +166,13 @@ if (props.isMainWindow) {
     "opsz" 24;
   width: 16px;
   height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.title .icon.material-symbols-outlined {
+  font-size: 18px;
 }
 
 .title-text {

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -97,7 +97,6 @@ if (props.isMainWindow) {
         <button v-if="hasHomeButton" class="app-button" tabindex="2" @click="navigateToDefault">
           <span class="material-symbols-outlined">home</span>
         </button>
-        <span class="divider"></span>
         <button v-if="hasSettingsButton" class="app-button" tabindex="3" @click="openSettingsWindow">
           <span class="material-symbols-outlined">settings</span>
         </button>
@@ -146,7 +145,6 @@ if (props.isMainWindow) {
 }
 
 .titlebar .right .app-buttons {
-  margin-right: 4px;
   display: flex;
   flex-direction: row;
 }
@@ -158,16 +156,16 @@ if (props.isMainWindow) {
 }
 
 .title .icon {
-  margin-left: 4px;
-  margin-right: 4px;
-  font-size: 24px;
+  margin-left: 8px;
+  margin-right: 8px;
+  font-size: 13px;
   font-variation-settings:
     "FILL" 0,
     "wght" 100,
     "GRAD" 0,
     "opsz" 24;
-  width: 24px;
-  height: 24px;
+  width: 16px;
+  height: 16px;
 }
 
 .title-text {
@@ -175,11 +173,12 @@ if (props.isMainWindow) {
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
+  font-size: 13px;
 }
 
 .app-button {
-  width: 28px;
-  height: 28px;
+  height: 35px;
+  width: 44px;
   background: none;
   color: #bbbbbb;
   display: flex;
@@ -187,17 +186,13 @@ if (props.isMainWindow) {
   justify-content: center;
   -webkit-app-region: no-drag;
   border: none;
-  border-radius: 4px;
+  border-radius: 0;
   font-variation-settings:
     "FILL" 0,
-    "wght" 100,
+    "wght" 200,
     "GRAD" 0,
     "opsz" 28;
   cursor: pointer;
-}
-
-.app-button:not(:last-child) {
-  margin-right: 4px;
 }
 
 .app-button:hover {
@@ -205,7 +200,8 @@ if (props.isMainWindow) {
 }
 
 .app-button > .material-symbols-outlined {
-  font-size: 28px;
+  font-size: 20px;
+  color: #b4b4b4;
 }
 
 .app-buttons .divider {

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -180,7 +180,7 @@ if (props.isMainWindow) {
   min-width: 0;
   white-space: nowrap;
   overflow: hidden;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .app-button {


### PR DESCRIPTION
# Summary
This pull request enhances the title-bar to make it a bit more consistent on windows devices. It's just a small change, but IMO looks better (we've also discussed about this in discord).

# What did exactly change?
I adjusted
- the font size of the "YouTube Music Desktop App" Title
- the main icon, so it's not as huge and "out of place"
- the right icons
  - I made the icons self smaller, so it's kinda the same size as the "official" windows buttons
  - I made the buttons (clickable space) somewhat the same size, as the "official" windows buttons
  - I removed the divider, so everything has somewhat the same distance to another (at least for the eyes)

# Comparison
**Before**
![image](https://github.com/user-attachments/assets/7da9fcfe-02be-407b-85d4-cc3b9997ff0b)

**After**
![image](https://github.com/user-attachments/assets/16cb32f0-cf63-47ef-b311-917da72420fb)

# Was that needed?
Not necessarily, but I think it's looking more consistent now and less "out of place". But that's just my opinion, if you think the original one is better, feel free to decline and close this pull request

# PS
I've also added `.idea` to the .gitignore. This is the JetBrains IDE settings folder.

# Addressed issues
This also somewhat addresses #1423 but not entirely (mac specific things weren't done, so it's just the icons on the right side, mentioned in the issue)
