### PR TITLE
Improve errors on invalid api requests by being less strict in schema

### DIFF
--- a/src/main/integrations/companion-server/api-shared/schemas.ts
+++ b/src/main/integrations/companion-server/api-shared/schemas.ts
@@ -19,10 +19,7 @@ export const APIV1CommandRequestBody = Type.Union([
   }),
   Type.Object({
     command: Type.Literal("setVolume"),
-    data: Type.Number({
-      minimum: 0,
-      maximum: 100
-    })
+    data: Type.Number()
   }),
   Type.Object({
     command: Type.Literal("mute")
@@ -32,9 +29,7 @@ export const APIV1CommandRequestBody = Type.Union([
   }),
   Type.Object({
     command: Type.Literal("seekTo"),
-    data: Type.Number({
-      minimum: 0
-    })
+    data: Type.Number()
   }),
   Type.Object({
     command: Type.Literal("next")
@@ -51,9 +46,7 @@ export const APIV1CommandRequestBody = Type.Union([
   }),
   Type.Object({
     command: Type.Literal("playQueueIndex"),
-    data: Type.Number({
-      minimum: 0
-    })
+    data: Type.Number()
   }),
   Type.Object({
     command: Type.Literal("changeVideo"),

--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -210,7 +210,7 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
           const index = commandRequest.data;
           const state = playerStateStore.getState();
 
-          if (isNaN(index) || index > state.queue.items.length + state.queue.automixItems.length - 1) {
+          if (isNaN(index) || index < 0 || index > state.queue.items.length + state.queue.automixItems.length - 1) {
             throw new InvalidQueueIndexError(index);
           }
 

--- a/src/main/integrations/companion-server/index.ts
+++ b/src/main/integrations/companion-server/index.ts
@@ -61,6 +61,19 @@ export default class CompanionServer implements IIntegration {
 
       reply.send(error);
     });
+    // Schema validation produces a lot of unhelpful errors,
+    // filter out only the relevant error when possible
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    this.fastifyServer.setSchemaErrorFormatter((errors, _) => {
+      for (const error of errors) {
+        if (error.message == "must match a schema in anyOf") return new Error("invalid command");
+        else if (error.message?.startsWith("must have required property") ?? false) {
+          return new Error(error.message);
+        }
+      }
+      // if all else fails, just send all errors as a string
+      return new Error(errors.toString());
+    });
     this.fastifyServer.get("/metadata", (request, reply) => {
       reply.send({
         apiVersions: ["v1"]


### PR DESCRIPTION
When calling the companion server API with incorrect parameters, it often produces unpleasant and hard to interpret error messages. For example, for the request `{ "command": "setVolume", "data": 101 }`, the API will respond:

```{
  "statusCode": 400,
  "code": "FST_ERR_VALIDATION",
  "error": "Bad Request",
  "message": "body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/data must be <= 100, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body/command must be equal to constant, body must match a schema in anyOf"
}
```

(This was formatted by the `reqwest` crate, but is still just representing the raw http response from the API.)

This is ultimately due to the error being produced by the fastify schema parser and listing every possible command and where in the parsing it failed (with all but one failing due to the `command` literal being that of a different command). By providing a custom schema error formatter in `companion-server/index.ts`, we can filter out most of those errors, but the rest still aren't very descriptive when `data` is out of range. So instead, we can just drop the range requirements from the schema, and let the callbacks for each command handle the range validation instead. In fact, all but one of them was *already* checking the range, despite it being validated by the schema.

With this change, the above response becomes:

```
{
  "statusCode": 400,
  "code": "INVALID_VOLUME",
  "error": "Bad Request",
  "message": "Volume '101' is invalid"
}
```
Additionally, requests with invalid commands become:
```
{
  "statusCode": 400,
  "code": "FST_ERR_VALIDATION",
  "error": "Bad Request",
  "message": "invalid command"
}
```
And commands with a missing `data` parameter become:

```
{
  "statusCode": 400,
  "code": "FST_ERR_VALIDATION",
  "error": "Bad Request",
  "message": "must have required property 'data'"
}
```