### PR TITLE
Companion API - Queue Modification

### DIFF
--- a/src/main/integrations/companion-server/api-shared/errors.ts
+++ b/src/main/integrations/companion-server/api-shared/errors.ts
@@ -7,6 +7,7 @@ const errorCodes = [
   "INVALID_SEEK_POSITION",
   "INVALID_QUEUE_INDEX",
   "INVALID_CHANGE_REQUEST",
+  "INVALID_QUEUE_ADD_REQUEST",
   "UNAUTHENTICATED",
   "AUTHORIZATION_DISABLED",
   "AUTHORIZATION_INVALID",
@@ -23,6 +24,7 @@ export const InvalidRepeatModeError = createError<[RepeatMode]>("INVALID_REPEAT_
 export const InvalidPositionError = createError<[number]>("INVALID_SEEK_POSITION", "Seek position '%s' is invalid", 400);
 export const InvalidQueueIndexError = createError<[number]>("INVALID_QUEUE_INDEX", "'%s' is an invalid queue index for the current queue", 400);
 export const InvalidChangeVideoRequestError = createError<[]>("INVALID_CHANGE_REQUEST", "'videoId', 'playlistId', or both must be provided", 400);
+export const InvalidQueueAddRequestError = createError<[]>("INVALID_QUEUE_ADD_REQUEST", "'videoId' or 'playlistId', must be provided", 400);
 export const UnauthenticatedError = createError<[]>("UNAUTHENTICATED", "Authentication not provided or invalid", 401);
 export const AuthorizationDisabledError = createError<[]>("AUTHORIZATION_DISABLED", "Authorization requests are disabled", 403);
 export const AuthorizationInvalidError = createError<[]>("AUTHORIZATION_INVALID", "Authorization invalid", 400);

--- a/src/main/integrations/companion-server/api-shared/schemas.ts
+++ b/src/main/integrations/companion-server/api-shared/schemas.ts
@@ -67,6 +67,33 @@ export const APIV1CommandRequestBody = Type.Union([
   }),
   Type.Object({
     command: Type.Literal("toggleDislike")
+  }),
+  Type.Object({
+    command: Type.Literal("queueAdd"),
+    data: Type.Object({
+      videoId: Type.Optional(Type.String()),
+      playlistId: Type.Optional(Type.String()),
+      index: Type.Number({
+        minimum: 0
+      })
+    })
+  }),
+  Type.Object({
+    command: Type.Literal("queueRemove"),
+    data: Type.Number({
+      minimum: 0
+    })
+  }),
+  Type.Object({
+    command: Type.Literal("queueMove"),
+    data: Type.Object({
+      fromIndex: Type.Number({
+        minimum: 0
+      }),
+      toIndex: Type.Number({
+        minimum: 0
+      })
+    })
   })
 ]);
 export type APIV1CommandRequestBodyType = Static<typeof APIV1CommandRequestBody>;

--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -25,7 +25,8 @@ import {
   InvalidVolumeError,
   UnauthenticatedError,
   YouTubeMusicTimeOutError,
-  YouTubeMusicUnavailableError
+  YouTubeMusicUnavailableError,
+  InvalidQueueAddRequestError
 } from "../../api-shared/errors";
 import path from "node:path";
 import Service from "../../../../services/service";
@@ -230,6 +231,61 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
 
         case "toggleDislike": {
           ytmView.webContents.send("remoteControl:execute", "toggleDislike");
+          break;
+        }
+
+        case "queueAdd": {
+          const videoId = commandRequest.data.videoId;
+          const playlistId = commandRequest.data.playlistId;
+          if (videoId == null && playlistId == null) {
+            throw new InvalidQueueAddRequestError();
+          } else if (videoId != null && playlistId != null) {
+            throw new InvalidQueueAddRequestError();
+          }
+
+          const index = commandRequest.data.index;
+          const state = playerStateStore.getState();
+          if (isNaN(index) || index > state.queue.items.length - 1) {
+            throw new InvalidQueueIndexError(index);
+          }
+
+          ytmView.webContents.send("remoteControl:execute", "queueAdd", {
+            videoId: videoId,
+            playlistId: playlistId,
+            index
+          });
+          break;
+        }
+
+        case "queueRemove": {
+          const index = commandRequest.data;
+          const state = playerStateStore.getState();
+
+          if (isNaN(index) || index > state.queue.items.length - 1) {
+            throw new InvalidQueueIndexError(index);
+          }
+
+          ytmView.webContents.send("remoteControl:execute", "queueRemove", index);
+          break;
+        }
+
+        case "queueMove": {
+          const fromIndex = commandRequest.data.fromIndex;
+          const toIndex = commandRequest.data.toIndex;
+          const state = playerStateStore.getState();
+
+          if (isNaN(fromIndex) || fromIndex > state.queue.items.length - 1) {
+            throw new InvalidQueueIndexError(fromIndex);
+          }
+
+          if (isNaN(toIndex) || toIndex > state.queue.items.length - 1) {
+            throw new InvalidQueueIndexError(toIndex);
+          }
+
+          ytmView.webContents.send("remoteControl:execute", "queueMove", {
+            fromIndex,
+            toIndex
+          });
           break;
         }
       }

--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -245,7 +245,7 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
 
           const index = commandRequest.data.index;
           const state = playerStateStore.getState();
-          if (isNaN(index) || index > state.queue.items.length - 1) {
+          if (isNaN(index) || index > state.queue.items.length) {
             throw new InvalidQueueIndexError(index);
           }
 

--- a/src/renderer/ytmview/scripts/queueadd.script.js
+++ b/src/renderer/ytmview/scripts/queueadd.script.js
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-unused-expressions */
+(function (videoId, playlistId, index) {
+  return new Promise((resolve, reject) => {
+    var returnValue = [];
+    var serviceRequestEvent = {
+      bubbles: true,
+      cancelable: false,
+      composed: true,
+      detail: {
+        actionName: "yt-service-request",
+        args: [
+          document.querySelector("ytmusic-app-layout>ytmusic-player-bar"),
+          {
+            queueAddEndpoint: {
+              queueTarget: {
+                videoId: videoId,
+                playlistId: playlistId
+              }
+            }
+          }
+        ],
+        optionalAction: false,
+        returnValue
+      }
+    };
+    document.querySelector("ytmusic-app-layout>ytmusic-player-bar").dispatchEvent(new CustomEvent("yt-action", serviceRequestEvent));
+    returnValue[0].ajaxPromise.then(
+      response => {
+        let items = response.data.queueDatas.map(data => data.content);
+        window.__YTMD_HOOK__.ytmStore.dispatch({
+          type: "ADD_ITEMS",
+          payload: {
+            nextQueueItemId: window.__YTMD_HOOK__.ytmStore.getState().queue.nextQueueItemId,
+            index,
+            items,
+            shuffleEnabled: window.__YTMD_HOOK__.ytmStore.getState().queue.shuffleEnabled,
+            shouldAssignIds: true
+          }
+        });
+        resolve();
+      },
+      () => {
+        reject();
+      }
+    );
+  });
+})

--- a/src/renderer/ytmview/setup.ts/4.remote.ts
+++ b/src/renderer/ytmview/setup.ts/4.remote.ts
@@ -2,6 +2,7 @@ import { ipcRenderer, webFrame } from "electron";
 import toggleLikeScript from "../scripts/togglelike.script?raw";
 import toggleDislikeScript from "../scripts/toggledislike.script?raw";
 import getPlaylistsScript from "../scripts/getplaylists.script?raw";
+import queueAddScript from "../scripts/queueadd.script?raw";
 
 function getYTMTextRun(runs: { text: string }[]) {
   let final = "";
@@ -293,6 +294,50 @@ export function attachIPCListeners() {
             }
           })
         );
+        break;
+      }
+
+      
+      case "queueAdd": {
+        await (
+          await webFrame.executeJavaScript(queueAddScript)
+        )(value.videoId, value.playlistId, value.index);
+        break;
+      }
+
+      case "queueRemove": {
+        const index: number = parseInt(value);
+
+        (
+          await webFrame.executeJavaScript(`
+            (function(index) {
+              window.__YTMD_HOOK__.ytmStore.dispatch({
+                type: "REMOVE_ITEM",
+                payload: index
+              });
+            })
+          `)
+        )(index);
+        break;
+      }
+
+      case "queueMove": {
+        const fromIndex: number = parseInt(value.fromIndex);
+        const toIndex: number = parseInt(value.toIndex);
+
+        (
+          await webFrame.executeJavaScript(`
+            (function(fromIndex, toIndex) {
+              window.__YTMD_HOOK__.ytmStore.dispatch({
+                type: "MOVE_ITEM",
+                payload: {
+                  fromIndex,
+                  toIndex
+                }
+              });
+            })
+          `)
+        )(fromIndex, toIndex);
         break;
       }
     }


### PR DESCRIPTION
Adds queue modification abilities to the Companion API

queueAdd allows arbitrarily adding a videoId/playlistId combination (refer to changeVideo for details) to the current queue. An index must be specified for where to place it within the queue.
```json
{
	"command": "queueAdd",
	"data": {
		"videoId": "dQw4w9WgXcQ",
		"index": 1
	}
}
```

queueRemove allows arbitrarily removing items from the queue. An index of which item in the queue to remove must be passed.
```json
{
	"command": "queueRemove",
	"data": 1
}
```

queueMove allows arbitrarily moving items within a queue. A fromIndex indicating what item to move and a toIndex indicating where the item will go.
```json
{
	"command": "queueMove",
	"data": {
		"fromIndex": 1,
		"toIndex": 2
	}
}
```