### PR TITLE
Frameless window support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ TODO: Write guides for v2. While these may still be helpful they are geared towa
 - Brew: ```brew install --cask ytmdesktop-youtube-music``` (Community Maintained)
 - Binaries: <https://github.com/ytmdesktop/ytmdesktop/releases>
 
+# Usage
+
+## Command Line Arguments
+
+- `--frameless` - Launch the application without a title bar
+
 # Developing
 To clone and run this repository you'll need [Git](https://git-scm.com) and [Node.js (v20)](https://nodejs.org/en/download/) (which comes with [npm](http://npmjs.com)) installed on your computer. From your command line:
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,6 @@ import {
   globalShortcut,
   ipcMain,
   Menu,
-  MenuItemConstructorOptions,
   nativeImage,
   nativeTheme,
   safeStorage,
@@ -156,9 +155,18 @@ log.info("Application launched");
 // Enforce sandbox on all renderers
 app.enableSandbox();
 
+// Parse --frameless flag early to avoid building menu unnecessarily
+const isFrameless = process.argv.includes("--frameless");
+
 // appMenu allows for some basic windows management, editMenu allow for copy and paste shortcuts on MacOS
-const template: MenuItemConstructorOptions[] = [{ role: "appMenu", label: "YouTube Music Desktop App" }, { role: "editMenu" }];
-const builtMenu = isDarwin ? Menu.buildFromTemplate(template) : null; // null for performance https://www.electronjs.org/docs/latest/tutorial/performance#8-call-menusetapplicationmenunull-when-you-do-not-need-a-default-menu
+// Only build menu if not running in frameless mode
+const builtMenu = !isFrameless && isDarwin ? Menu.buildFromTemplate([{ role: "appMenu", label: "YouTube Music Desktop App" }, { role: "editMenu" }]) : null;
+
+function updateApplicationMenu(visible: boolean) {
+  Menu.setApplicationMenu(visible ? builtMenu : null);
+}
+
+// Set initial menu
 Menu.setApplicationMenu(builtMenu);
 
 const companionServer = new CompanionServer();
@@ -257,8 +265,17 @@ memoryStore.onStateChanged((newState, oldState) => {
   if (ytmView !== null) {
     ytmView.webContents.send("memoryStore:stateChanged", newState, oldState);
   }
+
+  if (oldState && newState.titleBarVisible !== oldState.titleBarVisible) {
+    updateApplicationMenu(newState.titleBarVisible);
+    repositionYtmView();
+  }
 });
 log.info("Created memory store");
+
+memoryStore.set("titleBarVisible", !isFrameless);
+updateApplicationMenu(!isFrameless);
+log.info(`Title bar visibility initialized: ${!isFrameless} (frameless flag: ${isFrameless})`);
 
 function shouldDisableUpdates() {
   // macOS can't have auto updates without a code signature
@@ -868,6 +885,25 @@ function registerShortcuts() {
   log.info("Registered shortcuts");
 }
 
+// Constants
+const TITLE_BAR_HEIGHT = 36;
+
+// Helper function to reposition ytmView based on title bar visibility
+function repositionYtmView() {
+  if (!ytmView || !mainWindow) return;
+
+  const titleBarVisible = memoryStore.get("titleBarVisible");
+  const titleBarHeight = titleBarVisible ? TITLE_BAR_HEIGHT : 0;
+  const isFullScreen = mainWindow.fullScreen;
+
+  ytmView.setBounds({
+    x: 0,
+    y: isFullScreen ? 0 : titleBarHeight,
+    width: mainWindow.getContentBounds().width,
+    height: mainWindow.getContentBounds().height - (isFullScreen ? 0 : titleBarHeight)
+  });
+}
+
 // Functions which call to mainWindow renderer
 function sendMainWindowStateIpc() {
   if (mainWindow !== null) {
@@ -940,12 +976,6 @@ const createOrShowSettingsWindow = (): void => {
     icon: getIconPath("ytmd.png"),
     parent: mainWindow,
     modal: !isDarwin,
-    titleBarStyle: "hidden",
-    titleBarOverlay: {
-      color: "#000000",
-      symbolColor: "#BBBBBB",
-      height: 36
-    },
     webPreferences: {
       sandbox: true,
       contextIsolation: true,
@@ -1212,12 +1242,6 @@ const createMainWindow = (): void => {
     frame: false,
     show: false,
     icon: getIconPath("ytmd.png"),
-    titleBarStyle: "hidden",
-    titleBarOverlay: {
-      color: "#000000",
-      symbolColor: "#BBBBBB",
-      height: 36
-    },
     webPreferences: {
       sandbox: true,
       contextIsolation: true,
@@ -1237,47 +1261,19 @@ const createMainWindow = (): void => {
   // Attach events to main window
   mainWindow.on("resize", () => {
     setTimeout(() => {
-      if (ytmView) {
-        if (mainWindow.fullScreen) {
-          ytmView.setBounds({
-            x: 0,
-            y: 0,
-            width: mainWindow.getContentBounds().width,
-            height: mainWindow.getContentBounds().height
-          });
-        } else {
-          ytmView.setBounds({
-            x: 0,
-            y: 36,
-            width: mainWindow.getContentBounds().width,
-            height: mainWindow.getContentBounds().height - 36
-          });
-        }
-      }
+      repositionYtmView();
     });
   });
 
   mainWindow.on("enter-full-screen", () => {
     setTimeout(() => {
-      if (ytmView) {
-        ytmView.setBounds({
-          x: 0,
-          y: 0,
-          width: mainWindow.getContentBounds().width,
-          height: mainWindow.getContentBounds().height
-        });
-      }
+      repositionYtmView();
     });
     sendMainWindowStateIpc();
   });
   mainWindow.on("leave-full-screen", () => {
     setTimeout(() => {
-      ytmView.setBounds({
-        x: 0,
-        y: 36,
-        width: mainWindow.getContentBounds().width,
-        height: mainWindow.getContentBounds().height - 36
-      });
+      repositionYtmView();
     });
     sendMainWindowStateIpc();
   });
@@ -1576,12 +1572,7 @@ app.on("ready", async () => {
       memoryStore.set("ytmViewLoading", false);
       clearTimeout(ytmViewLoadTimeout);
       mainWindow.addBrowserView(ytmView);
-      ytmView.setBounds({
-        x: 0,
-        y: 36,
-        width: mainWindow.getContentBounds().width,
-        height: mainWindow.getContentBounds().height - 36
-      });
+      repositionYtmView();
       if (process.env.NODE_ENV === "development") {
         ytmView.webContents.openDevTools({
           mode: "detach"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1010,6 +1010,14 @@ const createOrShowSettingsWindow = (): void => {
     event.preventDefault();
   });
 
+  // Handle Escape key to close settings window
+  settingsWindow.webContents.on("before-input-event", (event, input) => {
+    if (input.type === "keyDown" && input.key === "Escape") {
+      event.preventDefault();
+      settingsWindow.close();
+    }
+  });
+
   settingsWindow.on("ready-to-show", () => {
     settingsWindow.show();
     // Open the DevTools.
@@ -1065,6 +1073,14 @@ const createYTMView = (): void => {
   ratioVolume.provide(ytmView);
 
   // Attach events to ytm view
+  // Handle Ctrl+, (Cmd+, on macOS) to open settings from ytmView
+  ytmView.webContents.on("before-input-event", (event, input) => {
+    if (input.type === "keyDown" && input.key === "," && (input.control || input.meta)) {
+      event.preventDefault();
+      createOrShowSettingsWindow();
+    }
+  });
+
   ytmView.webContents.on("will-navigate", event => {
     const url = new URL(event.url);
     if (isPreventedNavOrRedirect(url)) {
@@ -1305,6 +1321,14 @@ const createMainWindow = (): void => {
     if (process.env.NODE_ENV === "development") if (event.url.startsWith("http://localhost")) return;
 
     event.preventDefault();
+  });
+
+  // Handle Ctrl+, (Cmd+, on macOS) to open settings
+  mainWindow.webContents.on("before-input-event", (event, input) => {
+    if (input.type === "keyDown" && input.key === "," && (input.control || input.meta)) {
+      event.preventDefault();
+      createOrShowSettingsWindow();
+    }
   });
 
   mainWindow.on("ready-to-show", () => {

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -33,9 +33,20 @@ const closeWindow = window.ytmd.closeWindow;
 const openSettingsWindow = window.ytmd.openSettingsWindow;
 const navigateToDefault = window.ytmd.ytmViewNavigateDefault;
 
+const memoryStore = window.ytmd.memoryStore;
+
 const wcoVisible = ref(window.navigator.windowControlsOverlay.visible);
 const windowMaximized = ref(false);
 const windowFullscreen = ref(false);
+const titleBarVisible = ref<boolean>(true);
+
+onBeforeMount(async () => {
+  titleBarVisible.value = (await memoryStore.get("titleBarVisible")) ?? true;
+});
+
+memoryStore.onStateChanged(newState => {
+  titleBarVisible.value = newState.titleBarVisible;
+});
 
 window.ytmd.handleWindowEvents((event, state) => {
   windowMaximized.value = state.maximized;
@@ -69,7 +80,7 @@ if (props.isMainWindow) {
 </script>
 
 <template>
-  <div v-if="!windowFullscreen" class="titlebar">
+  <div v-if="!windowFullscreen && titleBarVisible" class="titlebar">
     <div class="left">
       <div class="title">
         <span v-if="icon" class="icon material-symbols-outlined">{{ icon }}</span>

--- a/src/renderer/windows/settings/Index.vue
+++ b/src/renderer/windows/settings/Index.vue
@@ -1,13 +1,25 @@
 <script setup lang="ts">
+import { onBeforeMount, ref } from "vue";
 import TitleBar from "../../components/TitleBar.vue";
 import Settings from "./Settings.vue";
+
+const memoryStore = window.ytmd.memoryStore;
+const titleBarVisible = ref<boolean>(true);
+
+onBeforeMount(async () => {
+  titleBarVisible.value = (await memoryStore.get("titleBarVisible")) ?? true;
+});
+
+memoryStore.onStateChanged(newState => {
+  titleBarVisible.value = newState.titleBarVisible;
+});
 </script>
 
 <template>
   <div class="container">
     <TitleBar class="titlebar" title="Settings" icon="settings" />
     <Suspense>
-      <Settings class="settings" />
+      <Settings :class="['settings', { 'no-titlebar': !titleBarVisible }]" />
     </Suspense>
   </div>
 </template>
@@ -17,6 +29,11 @@ import Settings from "./Settings.vue";
   border-top: 1px solid #212121;
   background-color: #000000;
   height: calc(100% - 36px);
+}
+
+.settings.no-titlebar {
+  height: 100%;
+  border-top: none;
 }
 
 .container {

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -83,4 +83,5 @@ export type MemoryStoreSchema = {
   ytmViewUnresponsive: boolean;
   appUpdateAvailable: boolean;
   appUpdateDownloaded: boolean;
+  titleBarVisible: boolean;
 };


### PR DESCRIPTION
Introducing a `--frameless` command-line argument for launching the application without a title bar, along with keyboard shortcuts for accessing Settings.

I run ytmdesktop on Wayland/Hyprland and would prefer a cleaner window since resizing and closing is handled via system shortcuts instead of in-app.

The keyboard shortcuts are fairly standard for Electron apps:
 - `Ctrl+,` (`Cmd+,` on macOS): Opens Settings window
 - `Escape`: Closes Settings window

## Notes
- Introduces centralized `repositionYtmView()` helper function that replaces hardcoded bounds calculations across resize
- Adds `titleBarVisible` to `MemoryStoreSchema`
- `TitleBar.vue`: Conditionally renders based on titleBarVisible state from memory store
