### PR TITLE
Migration from BrowserView to WebContentsView

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,7 @@
 import {
   app,
   autoUpdater,
-  BrowserView,
+  WebContentsView,
   BrowserWindow,
   clipboard,
   crashReporter,
@@ -172,7 +172,7 @@ const ytmViewIntegrationScripts: { [name: string]: { [name: string]: string } } 
 
 let mainWindow: BrowserWindow = null;
 let settingsWindow: BrowserWindow = null;
-let ytmView: BrowserView = null;
+let ytmView: WebContentsView = null;
 let tray: Tray = null;
 let trayContextMenu = null;
 
@@ -1021,7 +1021,7 @@ const createYTMView = (): void => {
   memoryStore.set("ytmViewLoading", true);
   memoryStore.set("ytmViewLoadingStatus", "Initializing...");
 
-  ytmView = new BrowserView({
+  ytmView = new WebContentsView({
     webPreferences: {
       sandbox: true,
       contextIsolation: true,
@@ -1030,6 +1030,7 @@ const createYTMView = (): void => {
       autoplayPolicy: store.get("playback.continueWhereYouLeftOffPaused") ? "document-user-activation-required" : "no-user-gesture-required"
     }
   });
+  ytmView.setBackgroundColor("#00000000");
   companionServer.provide(store, memoryStore, ytmView);
   customCss.provide(store, ytmView);
   ratioVolume.provide(ytmView);
@@ -1575,7 +1576,7 @@ app.on("ready", async () => {
 
       memoryStore.set("ytmViewLoading", false);
       clearTimeout(ytmViewLoadTimeout);
-      mainWindow.addBrowserView(ytmView);
+      mainWindow.contentView.addChildView(ytmView);
       ytmView.setBounds({
         x: 0,
         y: 36,
@@ -1664,7 +1665,7 @@ app.on("ready", async () => {
 
     if (ytmView) {
       if (mainWindow) {
-        mainWindow.removeBrowserView(ytmView);
+        mainWindow.contentView.removeChildView(ytmView);
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -1,4 +1,4 @@
-import { BrowserView, BrowserWindow, ipcMain } from "electron";
+import { WebContentsView, BrowserWindow, ipcMain } from "electron";
 import Conf from "conf";
 import { FastifyPluginCallback, FastifyPluginOptions } from "fastify";
 import { StoreSchema } from "~shared/store/schema";
@@ -84,7 +84,7 @@ const transformPlayerState = (state: PlayerState) => {
 
 interface CompanionServerAPIv1Options extends FastifyPluginOptions {
   getStore: () => Conf<StoreSchema>;
-  getYtmView: () => BrowserView;
+  getYtmView: () => WebContentsView;
 }
 
 type Playlist = {

--- a/src/main/integrations/companion-server/index.ts
+++ b/src/main/integrations/companion-server/index.ts
@@ -4,7 +4,7 @@ import FastifyIO from "fastify-socket.io/dist/index";
 import CompanionServerAPIv1 from "./api/v1";
 import { MemoryStoreSchema, StoreSchema } from "~shared/store/schema";
 import Conf from "conf";
-import { BrowserView, safeStorage } from "electron";
+import { WebContentsView, safeStorage } from "electron";
 import { TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
 import { AuthToken } from "~shared/integrations/companion-server/types";
 import { RemoteSocket } from "socket.io";
@@ -20,7 +20,7 @@ export default class CompanionServer implements IIntegration {
   private fastifyServer: FastifyInstance;
   private store: Conf<StoreSchema>;
   private memoryStore: MemoryStore<MemoryStoreSchema>;
-  private ytmView: BrowserView;
+  private ytmView: WebContentsView;
   private storeListener: () => void | null = null;
 
   private createServer() {
@@ -73,7 +73,7 @@ export default class CompanionServer implements IIntegration {
     });
   }
 
-  public provide(store: Conf<StoreSchema>, memoryStore: MemoryStore<MemoryStoreSchema>, ytmView: BrowserView): void {
+  public provide(store: Conf<StoreSchema>, memoryStore: MemoryStore<MemoryStoreSchema>, ytmView: WebContentsView): void {
     this.store = store;
     this.memoryStore = memoryStore;
     this.ytmView = ytmView;

--- a/src/main/integrations/custom-css/index.ts
+++ b/src/main/integrations/custom-css/index.ts
@@ -1,4 +1,4 @@
-import { BrowserView, ipcMain } from "electron";
+import { WebContentsView, ipcMain } from "electron";
 import fs from "fs";
 import Conf from "conf";
 
@@ -7,7 +7,7 @@ import { StoreSchema } from "~shared/store/schema";
 import { Unsubscribe } from "conf/dist/source/types";
 
 export default class CustomCSS implements IIntegration {
-  private ytmView: BrowserView;
+  private ytmView: WebContentsView;
   private store: Conf<StoreSchema>;
   private isEnabled = false;
   private hasInjectedOnce = false;
@@ -18,7 +18,7 @@ export default class CustomCSS implements IIntegration {
 
   private currentWatcher: fs.FSWatcher | null = null;
 
-  public provide(store: Conf<StoreSchema>, ytmView: BrowserView): void {
+  public provide(store: Conf<StoreSchema>, ytmView: WebContentsView): void {
     let ytmViewChanged = false;
     if (ytmView !== this.ytmView) {
       ytmViewChanged = true;

--- a/src/main/integrations/volume-ratio/index.ts
+++ b/src/main/integrations/volume-ratio/index.ts
@@ -1,4 +1,4 @@
-import { BrowserView } from "electron";
+import { WebContentsView } from "electron";
 import IIntegration from "../integration";
 
 import enableScript from "./script/enable.script?raw";
@@ -10,12 +10,12 @@ export default class VolumeRatio implements IIntegration {
   // https://greasyfork.org/en/scripts/397686-youtube-music-fix-volume-ratio
   // Made by: Marco Pfeiffer <git@marco.zone>
 
-  private ytmView: BrowserView;
+  private ytmView: WebContentsView;
   private hasInjected = false;
   private isEnabled = false;
   private waitForYTMView = true;
 
-  public provide(ytmView: BrowserView): void {
+  public provide(ytmView: WebContentsView): void {
     if (ytmView !== this.ytmView) {
       // The YTM view object has changed from what we knew it was. Invalidate the state as the YTM view was recreated
       this.hasInjected = false;


### PR DESCRIPTION
https://www.electronjs.org/blog/migrate-to-webcontentsview

[`BrowserView`](https://www.electronjs.org/docs/latest/api/browser-view) was officially deprecated in favor of [`WebContentsView`](https://www.electronjs.org/docs/latest/api/web-contents-view) with the [release of Electron 30](https://www.electronjs.org/blog/electron-30-0). 

## Notes
- Setting background color explicitly to transparent as `WebContentsView` defaults to a white background. `BrowserView` defaulted to a transparent background. This may not be completely necessary considering how styling is applied, but may prevent any potential white screen flashes as the page initially loads.
