### PR TITLE
Add theme mode settings (system/light/dark) with basic CSS

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -16,7 +16,8 @@ import {
   screen,
   session,
   shell,
-  Tray
+  Tray,
+  WebContents
 } from "electron";
 import Conf from "conf";
 import log from "electron-log";
@@ -26,7 +27,7 @@ import electronSquirrelStartup from "electron-squirrel-startup";
 
 import MemoryStore from "./memory-store";
 import playerStateStore, { PlayerState, VideoState } from "./player-state-store";
-import { MemoryStoreSchema, StoreSchema, TrayIconStyle } from "../shared/store/schema";
+import { MemoryStoreSchema, StoreSchema, TrayIconStyle, ThemeMode } from "../shared/store/schema";
 
 import CompanionServer from "./integrations/companion-server";
 import CustomCSS from "./integrations/custom-css";
@@ -354,7 +355,8 @@ const store = new Conf<StoreSchema>({
       customCSSEnabled: false,
       customCSSPath: null,
       zoom: 100,
-      trayIconStyle: TrayIconStyle.Auto
+      trayIconStyle: TrayIconStyle.Auto,
+      themeMode: 0 // Added by CtrlAubDel
     },
     playback: {
       continueWhereYouLeftOff: true,
@@ -425,6 +427,164 @@ const store = new Conf<StoreSchema>({
     }
   }
 });
+
+// START Theme additions by CtrlAubDel
+// START CSS Light/Dark Mode starters (pls fix this, I am bad at CSS!) - CtrlAubDel
+
+const LIGHT_THEME_CSS = `
+:root {
+  color-scheme: light;
+}
+
+/* Overall app background */
+html,
+body,
+ytmusic-app {
+  background-color: #f5f5f5 !important;
+  color: #111111 !important;
+}
+
+/* Main layout surfaces */
+ytmusic-app-layout,
+ytmusic-app-layout[has-bkg] #layout,
+ytmusic-browse-response {
+  background-color: #f5f5f5 !important;
+}
+
+/* Top nav bar */
+ytmusic-nav-bar {
+  background-color: #ffffff !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+
+/* Left sidebar */
+ytmusic-guide-renderer {
+  background-color: #ffffff !important;
+  border-right: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+/* Bottom player bar */
+ytmusic-player-bar {
+  background-color: #ffffff !important;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+/* Common text elements (titles, labels) */
+yt-formatted-string,
+ytmusic-responsive-list-item-renderer .title,
+ytmusic-two-row-item-renderer .title,
+ytmusic-description-shelf-renderer,
+ytmusic-detail-header-renderer {
+  color: #111111 !important;
+}
+
+/* Make buttons/controls match light surface */
+ytmusic-like-button-renderer,
+ytmusic-menu-renderer,
+ytmusic-play-button-renderer {
+  --ytmusic-button-background: #ffffff;
+}
+`;
+
+const DARK_THEME_CSS = `
+:root {
+  color-scheme: dark;
+}
+
+/* Overall app background */
+html,
+body,
+ytmusic-app {
+  background-color: #121212 !important;
+  color: #ffffff !important;
+}
+
+/* Main layout surfaces */
+ytmusic-app-layout,
+ytmusic-app-layout[has-bkg] #layout,
+ytmusic-browse-response {
+  background-color: #121212 !important;
+}
+
+/* Top nav bar */
+ytmusic-nav-bar {
+  background-color: #181818 !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+/* Left sidebar */
+ytmusic-guide-renderer {
+  background-color: #181818 !important;
+  border-right: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Bottom player bar */
+ytmusic-player-bar {
+  background-color: #181818 !important;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+/* Common text elements */
+yt-formatted-string,
+ytmusic-responsive-list-item-renderer .title,
+ytmusic-two-row-item-renderer .title,
+ytmusic-description-shelf-renderer,
+ytmusic-detail-header-renderer {
+  color: #ffffff !important;
+}
+
+/* Buttons/controls on dark background */
+ytmusic-like-button-renderer,
+ytmusic-menu-renderer,
+ytmusic-play-button-renderer {
+  --ytmusic-button-background: #181818;
+}
+`;
+
+// END CSS Light/Dark Mode starters (pls fix these, I am not the best at CSS) - CtrlAubDel
+
+let currentThemeCssKey: string | null = null;
+const currentThemeMode: ThemeMode = ThemeMode.System;
+
+async function applyThemeCssForCurrentSettings(): Promise<void> {
+  if (!ytmView || !ytmView.webContents) return;
+
+  const appearance = store.get("appearance") as StoreSchema["appearance"];
+  const mode = appearance.themeMode ?? ThemeMode.System;
+  const systemPrefersDark = nativeTheme.shouldUseDarkColors;
+
+  let css = "";
+  switch (mode) {
+    case ThemeMode.Light:
+      css = LIGHT_THEME_CSS;
+      break;
+    case ThemeMode.Dark:
+      css = DARK_THEME_CSS;
+      break;
+    case ThemeMode.System:
+    default:
+      css = systemPrefersDark ? DARK_THEME_CSS : LIGHT_THEME_CSS;
+      break;
+  }
+
+  const wc = ytmView.webContents as WebContents;
+
+  try {
+    if (currentThemeCssKey && wc.removeInsertedCSS) {
+      await wc.removeInsertedCSS(currentThemeCssKey);
+      currentThemeCssKey = null;
+    }
+
+    if (css && wc.insertCSS) {
+      currentThemeCssKey = await wc.insertCSS(css);
+    }
+  } catch (error) {
+    log.error("Failed to apply theme CSS", error);
+  }
+}
+
+// END Theme additions by CtrlAubDel
+
 store.onDidAnyChange(async (newState, oldState) => {
   if (settingsWindow !== null) {
     settingsWindow.webContents.send("settings:stateChanged", newState, oldState);
@@ -469,6 +629,12 @@ store.onDidAnyChange(async (newState, oldState) => {
     log.info("Integration disabled: Custom CSS");
   }
   if (oldState.appearance.trayIconStyle !== newState.appearance.trayIconStyle) setTrayIcon();
+
+  if (oldState.appearance.themeMode !== newState.appearance.themeMode) {
+    applyThemeMode(newState.appearance.themeMode);
+    void applyThemeCssForCurrentSettings();
+    log.info(`Appearance: theme mode set to ${newState.appearance.themeMode}`);
+  }
 
   // Playback
   if (newState.playback.ratioVolume) {
@@ -695,6 +861,21 @@ function getTrayIconPath() {
 
 function setTrayIcon() {
   tray.setImage(getTrayIconPath());
+}
+
+function applyThemeMode(mode: ThemeMode) {
+  // Added by CtrlAubDel
+  switch (mode) {
+    case ThemeMode.Light:
+      nativeTheme.themeSource = "light";
+      break;
+    case ThemeMode.Dark:
+      nativeTheme.themeSource = "dark";
+      break;
+    case ThemeMode.System:
+      nativeTheme.themeSource = "system";
+      break;
+  }
 }
 
 // Shortcut registration
@@ -1162,6 +1343,8 @@ const createYTMView = (): void => {
     if (!memoryStore.get("ytmViewLoadingError")) {
       memoryStore.set("ytmViewLoadingStatus", "Loaded YouTube Music");
     }
+
+    void applyThemeCssForCurrentSettings(); // Added by CtrlAubDel
   });
 
   ytmView.webContents.on("did-fail-load", (_event, errorCode, errorDescription, _validatedURL, isMainFrame) => {
@@ -1331,6 +1514,9 @@ const createMainWindow = (): void => {
 // Some APIs can only be used after this event occurs.
 app.on("ready", async () => {
   log.info("Application ready");
+
+  const appearance = store.get("appearance") as StoreSchema["appearance"]; // Added by CtrlAubDel
+  applyThemeMode(appearance.themeMode ?? ThemeMode.System); //
 
   // First run checks
   const firstRunPath = path.join(app.getPath("userData"), ".first-run");
@@ -1953,7 +2139,15 @@ app.on("ready", async () => {
     log.info("Integration enabled: Last.fm");
   }
 
-  nativeTheme.on("updated", setTrayIcon);
+  nativeTheme.on("updated", () => {
+    // Added by CtrlAubDel
+    setTrayIcon(); //
+
+    if (currentThemeMode === ThemeMode.System) {
+      //
+      void applyThemeCssForCurrentSettings(); //
+    }
+  });
 });
 
 app.on("before-quit", () => {

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -2,7 +2,7 @@
 import { ref } from "vue";
 import KeybindInput from "../../components/KeybindInput.vue";
 import YTMDSetting from "../../components/YTMDSetting.vue";
-import { StoreSchema, TrayIconStyle } from "~shared/store/schema";
+import { StoreSchema, TrayIconStyle, ThemeMode } from "~shared/store/schema"; // CtrlAubDel added ThemeMode
 import { AuthToken } from "~shared/integrations/companion-server/types";
 import logo from "~assets/icons/ytmd.png";
 
@@ -47,6 +47,7 @@ const customCSSEnabled = ref<boolean>(appearance.customCSSEnabled);
 const customCSSPath = ref<string>(appearance.customCSSPath);
 const zoom = ref<number>(appearance.zoom);
 const trayIconStyle = ref<number>(appearance.trayIconStyle);
+const themeMode = ref<ThemeMode>(appearance.themeMode ?? ThemeMode.System); // Added by CtrlAubDel
 
 const continueWhereYouLeftOff = ref<boolean>(playback.continueWhereYouLeftOff);
 const continueWhereYouLeftOffPaused = ref<boolean>(playback.continueWhereYouLeftOffPaused);
@@ -158,6 +159,8 @@ async function settingsChanged() {
   store.set("appearance.customCSSEnabled", customCSSEnabled.value);
   store.set("appearance.zoom", zoom.value);
   store.set("appearance.trayIconStyle", trayIconStyle.value);
+
+  store.set("appearance.themeMode", themeMode.value); // Added by CtrlAubDel
 
   store.set("playback.continueWhereYouLeftOff", continueWhereYouLeftOff.value);
   store.set("playback.continueWhereYouLeftOffPaused", continueWhereYouLeftOffPaused.value);
@@ -315,6 +318,19 @@ window.ytmd.handleUpdateDownloaded(() => {
             @clear="removeCustomCSSPath"
           />
           <YTMDSetting v-model="zoom" type="range" max="300" min="30" step="10" name="Zoom" @change="settingsChanged" />
+
+          <YTMDSetting
+            v-model="themeMode"
+            :options-map="{
+              [ThemeMode.System]: 'System',
+              [ThemeMode.Light]: 'Light',
+              [ThemeMode.Dark]: 'Dark'
+            }"
+            type="select"
+            name="Theme"
+            @change="settingsChanged"
+          />
+
           <YTMDSetting
             v-if="isLinux"
             v-model="trayIconStyle"

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -4,6 +4,12 @@ export enum TrayIconStyle {
   Black = 2
 }
 
+export enum ThemeMode { // Added by CtrlAubDel
+  System = 0, //
+  Light = 1, //
+  Dark = 2 //
+}
+
 export type StoreSchema = {
   metadata: {
     version: 1;
@@ -21,6 +27,7 @@ export type StoreSchema = {
     customCSSPath: string | null;
     zoom: number;
     trayIconStyle: TrayIconStyle;
+    themeMode: ThemeMode; // Addde by CtrlAubDel
   };
   playback: {
     continueWhereYouLeftOff: boolean;


### PR DESCRIPTION
This PR adds a Theme setting under **Settings → Appearance** with three options:

- **System** – follows the OS theme
- **Light** – forces a light theme
- **Dark** – forces a dark theme

Internally it:

- Adds `appearance.themeMode` to the config (backed by a `ThemeMode` enum).
- Maps `themeMode` to `nativeTheme.themeSource` (`system | light | dark`).
- Injects small CSS overrides into the YouTube Music `BrowserView` so the chosen theme is visible.
- Updates the theme CSS when:
  - The setting changes
  - The YTM view finishes loading
  - The OS theme changes (when mode is **System**)

The CSS is intentionally minimal and focuses on the main shells (nav bar, sidebar, player bar, app background) so it should be easy to refine in follow-up PRs.

Please see attached screenshot of what it looks like.

This is my attempt at contributing towards the following open issue:
[https://github.com/ytmdesktop/ytmdesktop/issues/1600](https://github.com/ytmdesktop/ytmdesktop/issues/1600)

<img width="1919" height="1076" alt="image" src="https://github.com/user-attachments/assets/b183f437-8ec3-4437-bfa8-fdffce4fff7f" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/5bc4676d-a1f4-406e-9a51-07059a6ec6e7" />
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/7cfee8a6-4025-4bc1-956f-d7f05825adcb" />
