### PR TITLE
Artist name on Discord rich presence status

### DIFF
--- a/src/main/integrations/discord-presence/index.ts
+++ b/src/main/integrations/discord-presence/index.ts
@@ -77,6 +77,7 @@ export default class DiscordPresence implements IIntegration {
       const thumbnail = getHighestResThumbnail(thumbnails);
       this.discordClient.setActivity({
         type: DiscordActivityType.Listening,
+        name: stringLimit(author, 128, 2),
         details: stringLimit(title, 128, 2),
         state: stringLimit(author, 128, 2),
         timestamps: {

--- a/src/main/integrations/discord-presence/minimal-discord-client/types.ts
+++ b/src/main/integrations/discord-presence/minimal-discord-client/types.ts
@@ -9,6 +9,7 @@ export enum DiscordActivityType {
 
 export type DiscordActivity = {
   type?: DiscordActivityType;
+  name?: string;
   state?: string;
   details?: string;
   timestamps?: {


### PR DESCRIPTION
Make Discord show artist name in the banner instead of "Youtube Music", just like Spotify

Spotify:
<img width="248" height="48" alt="image" src="https://github.com/user-attachments/assets/132c87d1-7d75-4637-8fd2-a354f486e92b" />

Current:
<img width="253" height="49" alt="image" src="https://github.com/user-attachments/assets/52b39e79-10e8-4c27-9c45-d2fa294b9579" />

New:
<img width="259" height="49" alt="image" src="https://github.com/user-attachments/assets/9042b5b0-a7ac-4f14-bb8f-498dd65edbe8" />
