### PR TITLE
Add configurable volume delta for shortcuts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -377,7 +377,8 @@ const store = new Conf<StoreSchema>({
       thumbsUp: "",
       thumbsDown: "",
       volumeUp: "",
-      volumeDown: ""
+      volumeDown: "",
+      volumeDelta: 10
     },
     state: {
       lastUrl: "https://music.youtube.com/",

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -69,6 +69,7 @@ const shortcutThumbsUp = ref<string>(shortcuts.thumbsUp);
 const shortcutThumbsDown = ref<string>(shortcuts.thumbsDown);
 const shortcutVolumeUp = ref<string>(shortcuts.volumeUp);
 const shortcutVolumeDown = ref<string>(shortcuts.volumeDown);
+const shortcutsVolumeDelta = ref<number>(shortcuts.volumeDelta);
 
 const lastFMSessionKey = ref<string>(lastFM.sessionKey);
 const scrobblePercent = ref<number>(lastFM.scrobblePercent);
@@ -178,6 +179,7 @@ async function settingsChanged() {
   store.set("shortcuts.thumbsDown", shortcutThumbsDown.value);
   store.set("shortcuts.volumeUp", shortcutVolumeUp.value);
   store.set("shortcuts.volumeDown", shortcutVolumeDown.value);
+  store.set("shortcuts.volumeDelta", shortcutsVolumeDelta.value);
 }
 
 async function settingChangedRequiresRestart() {
@@ -517,6 +519,7 @@ window.ytmd.handleUpdateDownloaded(() => {
             </p>
             <KeybindInput v-model="shortcutVolumeDown" @change="settingsChanged" />
           </div>
+          <YTMDSetting v-model="shortcutsVolumeDelta" type="range" max="20" min="1" step="1" name="Volume Delta %" @change="settingsChanged" />
         </div>
 
         <div v-if="currentTab === 99" class="about-tab">

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -438,8 +438,9 @@ window.addEventListener("load", async () => {
           `)
         )();
 
-        let newVolumeUp = currentVolumeUp + 10;
-        if (currentVolumeUp > 100) {
+        const volumeDelta = Number(await store.get("shortcuts.volumeDelta"));
+        let newVolumeUp = currentVolumeUp + volumeDelta;
+        if (newVolumeUp > 100) {
           newVolumeUp = 100;
         }
         (
@@ -462,8 +463,9 @@ window.addEventListener("load", async () => {
           `)
         )();
 
-        let newVolumeDown = currentVolumeDown - 10;
-        if (currentVolumeDown < 0) {
+        const volumeDelta = Number(await store.get("shortcuts.volumeDelta"));
+        let newVolumeDown = currentVolumeDown - volumeDelta;
+        if (newVolumeDown < 0) {
           newVolumeDown = 0;
         }
         (

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -44,6 +44,7 @@ export type StoreSchema = {
     thumbsDown: string;
     volumeUp: string;
     volumeDown: string;
+    volumeDelta: number;
   };
   state: {
     lastUrl: string;


### PR DESCRIPTION
Configurable volume delta for shortcuts - the current value is hardcoded to 10% which does not allow precise control. Added a slider which allows to select between 1-20%.

<img width="1000" height="751" alt="image" src="https://github.com/user-attachments/assets/fb4d797a-17ee-4fd9-a28b-545841ca3457" />
