### PR TITLE
Add support for proxy server

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -347,7 +347,8 @@ const store = new Conf<StoreSchema>({
       hideToTrayOnClose: false,
       showNotificationOnSongChange: false,
       startOnBoot: false,
-      startMinimized: false
+      startMinimized: false,
+      proxyServer: ""
     },
     appearance: {
       alwaysShowVolumeSlider: false,
@@ -558,6 +559,10 @@ if (store.get("general").disableHardwareAcceleration) {
 
 if (store.get("playback").enableSpeakerFill) {
   app.commandLine.appendSwitch("try-supported-channel-layouts");
+}
+
+if (store.get("general").proxyServer) {
+  app.commandLine.appendSwitch("proxy-server", store.get("general").proxyServer);
 }
 
 function saveState() {

--- a/src/renderer/components/YTMDSetting.vue
+++ b/src/renderer/components/YTMDSetting.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" generic="T extends 'checkbox' | 'file' | 'range' | 'select' | 'custom'">
+<script setup lang="ts" generic="T extends 'checkbox' | 'file' | 'range' | 'select' | 'custom' | 'text'">
 import { computed, ref } from "vue";
 
 type ModelValue = {
@@ -7,6 +7,7 @@ type ModelValue = {
   range: number;
   custom: never;
   select: number;
+  text: string;
 };
 
 const props = defineProps<{
@@ -78,12 +79,15 @@ function select(optionKey: string) {
     </div>
 
     <input
-      v-if="type !== 'file' && type !== 'range' && type !== 'select' && type !== 'custom'"
+      v-if="type !== 'file' && type !== 'range' && type !== 'select' && type !== 'custom' && type !== 'text'"
       v-model="value"
       :disabled="disabled"
       :type="props.type"
       @change="$emit('change', $event)"
     />
+    <div v-if="type == 'text'" class="text-input">
+      <input v-model="value" :disabled="disabled" type="text" @change="$emit('change', $event)" />
+    </div>
     <div v-if="type == 'range'" class="range-selector">
       <span class="range-value">{{ value }}</span>
       <input v-model="value" :disabled="disabled" :type="props.type" :max="props.max" :min="props.min" :step="props.step" @change="$emit('change', $event)" />
@@ -337,5 +341,25 @@ input[type="range"]::-webkit-slider-thumb {
 
 .select:not(.open) .options {
   display: none;
+}
+
+.text-input {
+  background-color: #212121;
+  border-radius: 4px;
+  width: 216px;
+}
+
+.text-input input {
+  margin: 0;
+  padding: 8px;
+  width: 100%;
+  border: none;
+  background-color: transparent;
+  box-sizing: border-box;
+}
+
+.text-input input:focus,
+.text-input input:active {
+  outline: none;
 }
 </style>

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -41,6 +41,7 @@ const hideToTrayOnClose = ref<boolean>(general.hideToTrayOnClose);
 const showNotificationOnSongChange = ref<boolean>(general.showNotificationOnSongChange);
 const startOnBoot = ref<boolean>(general.startOnBoot);
 const startMinimized = ref<boolean>(general.startMinimized);
+const proxyServer = ref<string>(general.proxyServer);
 
 const alwaysShowVolumeSlider = ref<boolean>(appearance.alwaysShowVolumeSlider);
 const customCSSEnabled = ref<boolean>(appearance.customCSSEnabled);
@@ -79,6 +80,7 @@ store.onDidAnyChange(async newState => {
   showNotificationOnSongChange.value = newState.general.showNotificationOnSongChange;
   startOnBoot.value = newState.general.startOnBoot;
   startMinimized.value = newState.general.startMinimized;
+  proxyServer.value = newState.general.proxyServer;
 
   alwaysShowVolumeSlider.value = newState.appearance.alwaysShowVolumeSlider;
   customCSSEnabled.value = newState.appearance.customCSSEnabled;
@@ -153,6 +155,7 @@ async function settingsChanged() {
   store.set("general.startOnBoot", startOnBoot.value);
   store.set("general.startMinimized", startMinimized.value);
   store.set("general.disableHardwareAcceleration", disableHardwareAcceleration.value);
+  store.set("general.proxyServer", proxyServer.value);
 
   store.set("appearance.alwaysShowVolumeSlider", alwaysShowVolumeSlider.value);
   store.set("appearance.customCSSEnabled", customCSSEnabled.value);
@@ -299,6 +302,7 @@ window.ytmd.handleUpdateDownloaded(() => {
             name="Disable hardware acceleration"
             @change="settingChangedRequiresRestart"
           />
+          <YTMDSetting v-model="proxyServer" type="text" restart-required name="Proxy server" @change="settingChangedRequiresRestart" />
         </div>
 
         <div v-if="currentTab === 2" class="appearance-tab">

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -14,6 +14,7 @@ export type StoreSchema = {
     showNotificationOnSongChange: boolean;
     startOnBoot: boolean;
     startMinimized: boolean;
+    proxyServer: string;
   };
   appearance: {
     alwaysShowVolumeSlider: boolean;


### PR DESCRIPTION
Support for proxy servers - this is required mainly for countries where YouTube Music is not available. Should work the same as setting  `--proxy-server=server:port` but done through settings. Previously was using this parameter on a shortcut and an update just recreated the shortcut without this parameter.

<img width="1004" height="753" alt="image" src="https://github.com/user-attachments/assets/61b25780-2832-451d-9238-287bc41a24a5" />