### PR TITLE
:sparkles: Add Server-Sent Events (SSE) for Realtime API Updates

### DIFF
--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -30,6 +30,7 @@ import {
   YouTubeMusicUnavailableError
 } from "../../api-shared/errors";
 import path from "node:path";
+import { ServerResponse } from "node:http";
 
 declare const ALL_WINDOWS_VITE_DEV_SERVER_URL: string;
 
@@ -95,6 +96,73 @@ type Playlist = {
 const authorizationWindows: BrowserWindow[] = [];
 
 const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> = async (fastify, options) => {
+  type RealtimeEventName = "state-update" | "playlist-created" | "playlist-deleted";
+
+  type SseClient = {
+    id: string;
+    response: ServerResponse;
+    heartbeatInterval: NodeJS.Timeout;
+  };
+
+  const sseClients = new Map<string, SseClient>();
+
+  const writeSseEvent = (response: ServerResponse, eventName: RealtimeEventName, payload: unknown) => {
+    if (response.writableEnded) {
+      return;
+    }
+    let data: string;
+    try {
+      const json = JSON.stringify(payload);
+      data = json ?? "null";
+    } catch {
+      data = JSON.stringify({
+        error: "UNSERIALIZABLE_PAYLOAD"
+      });
+    }
+    response.write(`event: ${eventName}\n`);
+    response.write(`data: ${data}\n\n`);
+  };
+
+  const emitRealtimeEvent = (eventName: RealtimeEventName, payload: unknown) => {
+    fastify.io.of("/api/v1/realtime").emit(eventName, payload);
+
+    const staleClients: string[] = [];
+    for (const client of sseClients.values()) {
+      if (client.response.writableEnded) {
+        staleClients.push(client.id);
+        continue;
+      }
+      writeSseEvent(client.response, eventName, payload);
+    }
+
+    for (const clientId of staleClients) {
+      removeSseClient(clientId);
+    }
+  };
+
+  const removeSseClient = (clientId: string) => {
+    const client = sseClients.get(clientId);
+    if (!client) {
+      return;
+    }
+
+    clearInterval(client.heartbeatInterval);
+    if (!client.response.writableEnded) {
+      client.response.end();
+    }
+    sseClients.delete(clientId);
+  };
+
+  const closeAllSseClients = () => {
+    for (const client of sseClients.values()) {
+      clearInterval(client.heartbeatInterval);
+      if (!client.response.writableEnded) {
+        client.response.end();
+      }
+    }
+    sseClients.clear();
+  };
+
   const sendCommand = (commandRequest: APIV1CommandRequestBodyType) => {
     const ytmView = options.getYtmView();
     if (ytmView) {
@@ -513,6 +581,55 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
     }
   );
 
+  fastify.get(
+    "/realtime/sse",
+    {
+      preHandler: (request, response, next) => {
+        return isAuthValidMiddleware(options.getStore(), request, response, next);
+      }
+    },
+    (request, reply) => {
+      const headers = {
+        ...reply.getHeaders(),
+        "Content-Type": "text/event-stream; charset=utf-8",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no"
+      };
+
+      reply.raw.writeHead(200, headers as any);
+      reply.hijack();
+
+      const clientId = crypto.randomUUID();
+      reply.raw.setTimeout(0);
+
+      const heartbeatInterval = setInterval(() => {
+        if (reply.raw.writableEnded) {
+          removeSseClient(clientId);
+          return;
+        }
+        reply.raw.write(": ping\n\n");
+      }, 1000 * 15);
+
+      sseClients.set(clientId, {
+        id: clientId,
+        response: reply.raw,
+        heartbeatInterval
+      });
+
+      writeSseEvent(reply.raw, "state-update", transformPlayerState(playerStateStore.getState()));
+
+      const cleanup = () => {
+        removeSseClient(clientId);
+      };
+
+      request.raw.on("close", cleanup);
+      request.raw.on("aborted", cleanup);
+      reply.raw.on("close", cleanup);
+      reply.raw.on("error", cleanup);
+    }
+  );
+
   fastify.ready().then(() => {
     fastify.io.of("/api/v1/realtime").use((socket, next) => {
       const token = socket.handshake.auth.token;
@@ -532,7 +649,7 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
     });*/
 
     const stateStoreListener = (state: PlayerState) => {
-      fastify.io.of("/api/v1/realtime").emit("state-update", transformPlayerState(state));
+      emitRealtimeEvent("state-update", transformPlayerState(state));
     };
     playerStateStore.addEventListener(stateStoreListener);
 
@@ -540,7 +657,7 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
       const ytmView = options.getYtmView();
       if (event.sender !== ytmView.webContents) return;
 
-      fastify.io.of("/api/v1/realtime").emit("playlist-created", playlist);
+      emitRealtimeEvent("playlist-created", playlist);
     };
     ipcMain.on("ytmView:createPlaylistObserved", createPlaylistObservedListener);
 
@@ -548,13 +665,14 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
       const ytmView = options.getYtmView();
       if (event.sender !== ytmView.webContents) return;
 
-      fastify.io.of("/api/v1/realtime").emit("playlist-deleted", playlistId);
+      emitRealtimeEvent("playlist-deleted", playlistId);
     };
     ipcMain.on("ytmView:deletePlaylistObserved", deletePlaylistObservedListener);
 
     fastify.addHook("onClose", () => {
       // This should normally close on its own but we'll make sure it's closed out
       fastify.io.close();
+      closeAllSseClients();
       playerStateStore.removeEventListener(stateStoreListener);
       ipcMain.off("ytmView:createPlaylistObserved", createPlaylistObservedListener);
       ipcMain.off("ytmView:deletePlaylistObserved", deletePlaylistObservedListener);


### PR DESCRIPTION
This PR adds **Server-Sent Events (SSE)** as an additional realtime transport to the Companion Server API v1.  
SSE complements the existing Socket.IO channel and provides a simpler, more portable way to consume realtime updates—especially for non-JavaScript clients.

---

## What’s New

### New endpoint
- **`GET /api/v1/realtime/sse`**
  - Authenticated using the **same auth flow and middleware as regular REST endpoints**
  - Uses `text/event-stream`
  - Keeps connections alive and disables proxy buffering

### Unified realtime event emission
A new internal helper (`emitRealtimeEvent`) broadcasts events to **both**:
- Socket.IO namespace: `/api/v1/realtime`
- All connected SSE clients

### Supported events
- `state-update`
- `playlist-created`
- `playlist-deleted`

### Initial sync
- Clients immediately receive a `state-update` event after connecting

### Connection management
- Heartbeat comments (`: ping`) every 15 seconds
- Automatic cleanup on:
  - client disconnect / abort
  - stream errors
  - stale connections
- All SSE connections are closed gracefully on server shutdown

---

## ⚠️ Important Caveat: `EventSource` is NOT supported

Although this endpoint uses the SSE protocol, **browser `EventSource` cannot be used**.

**Reason:**
- The Companion API intentionally uses the **same authentication mechanism as REST endpoints**
- Authentication tokens **must be sent via headers**
- Tokens in URLs / query parameters are explicitly **not allowed**
- The `EventSource` API **does not support custom headers**

**Result:** `EventSource` cannot authenticate and will fail.

---

## How to consume SSE correctly (browser example)

SSE **does work** using `fetch()` with streaming, which supports headers.

Below is a minimal browser example derived from the debug client used during development:

```js
const res = await fetch("/api/v1/realtime/sse", {
  headers: {
    "Accept": "text/event-stream",
    "Authorization": token, // token value as defined by API docs
    "Cache-Control": "no-cache",
  },
  cache: "no-store",
});

if (!res.ok || !res.body) {
  throw new Error("Failed to connect to SSE");
}

const reader = res.body.getReader();
const decoder = new TextDecoder("utf-8");
let buffer = "";

while (true) {
  const { value, done } = await reader.read();
  if (done) break;

  buffer += decoder.decode(value, { stream: true });

  // SSE frames are separated by a blank line
  const frames = buffer.split("\n\n");
  buffer = frames.pop() ?? "";

  for (const frame of frames) {
    if (!frame.trim()) continue;

    // Heartbeat / comment
    if (frame.startsWith(":")) continue;

    let event = "message";
    let data = "";

    for (const line of frame.split("\n")) {
      if (line.startsWith("event:")) event = line.slice(6).trim();
      if (line.startsWith("data:")) data += line.slice(5).trim();
    }

    try {
      data = JSON.parse(data);
    } catch {
      /* keep raw string */
    }

    console.log("[sse]", event, data);
  }
}
```

---

## Why SSE?

Even with the `EventSource` limitation, SSE brings major benefits:

- **Much easier to consume in other languages**
  - Plain HTTP streaming works well in Go, Rust, Python, Java, etc.
  - Socket.IO support outside JavaScript is complex and unreliable
- **Lower overhead for read-only realtime data**
  - Ideal for state updates, playlist changes, dashboards, and monitoring
- **No breaking changes**
  - Existing Socket.IO clients continue to work unchanged
  - SSE is fully optional and additive

---

## Security & Compatibility

- No auth tokens in URLs or query parameters
- Same auth validation as REST endpoints
- No breaking API changes
- Socket.IO remains the default bidirectional realtime solution

---

**Summary:**  
This PR adds a secure, portable, and low-overhead realtime option to the Companion Server API while keeping full backwards compatibility and strict auth guarantees.
