### PR TITLE
✨ Add macOS Dock playback controls

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1872,6 +1872,41 @@ app.on("ready", async () => {
 
   log.info("Created tray icon");
 
+  // macOS Dock right-click menu with playback controls
+  if (isDarwin) {
+    const dockMenu = Menu.buildFromTemplate([
+      {
+        label: "Play/Pause",
+        type: "normal",
+        click: () => {
+          ytmView.webContents.send("remoteControl:execute", "playPause");
+        }
+      },
+      {
+        label: "Next",
+        type: "normal",
+        click: () => {
+          ytmView.webContents.send("remoteControl:execute", "next");
+        }
+      },
+      {
+        label: "Previous",
+        type: "normal",
+        click: () => {
+          ytmView.webContents.send("remoteControl:execute", "previous");
+        }
+      },
+      {
+        label: "Stop",
+        type: "normal",
+        click: () => {
+          ytmView.webContents.send("remoteControl:execute", "stop");
+        }
+      }
+    ]);
+    app.dock.setMenu(dockMenu);
+  }
+
   createMainWindow();
   log.info("Created main window");
 

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -372,6 +372,19 @@ window.addEventListener("load", async () => {
         break;
       }
 
+      case "stop": {
+        (
+          await webFrame.executeJavaScript(`
+            (function() {
+              var playerBar = document.querySelector("ytmusic-app-layout>ytmusic-player-bar");
+              playerBar.playerApi.pauseVideo();
+              playerBar.playerApi.seekTo(0);
+            })
+          `)
+        )();
+        break;
+      }
+
       case "next": {
         (
           await webFrame.executeJavaScript(`


### PR DESCRIPTION
## Summary
- Add playback control menu items (Play/Pause, Next, Previous, Stop) to the macOS Dock right-click menu via `app.dock.setMenu()`
- Add a new `stop` remote control command that pauses playback and seeks to the beginning of the track (`pauseVideo()` + `seekTo(0)`)
- Only activates on macOS (`isDarwin` guard)

## Test plan
- [ ] On macOS, right-click the Dock icon and verify Play/Pause, Next, Previous, Stop items appear above the default menu items
- [ ] Play a track, click "Stop" from the Dock menu — verify playback pauses and progress resets to 0
- [ ] Click "Play/Pause" — verify playback toggles correctly
- [ ] Click "Next" / "Previous" — verify track changes
- [ ] On non-macOS platforms, verify no errors (dock menu code is guarded by `isDarwin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)