### PR TITLE
🐛 Add timeout to update check to prevent infinite loading

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1882,8 +1882,17 @@ app.on("ready", async () => {
   if (app.isPackaged && !shouldDisableUpdates() && !YTMD_DISABLE_UPDATES) {
     autoUpdater.checkForUpdates();
     await new Promise<void>(resolve => {
-      setInterval(() => {
-        if (!appLaunchUpdateCheck) resolve();
+      const timeout = setTimeout(() => {
+        log.warn("Update check timed out, continuing app launch");
+        appLaunchUpdateCheck = false;
+        resolve();
+      }, 10000);
+      const interval = setInterval(() => {
+        if (!appLaunchUpdateCheck) {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          resolve();
+        }
       }, 250);
     });
   } else {


### PR DESCRIPTION
## Summary
Fixes #1601

When the update server is inaccessible (e.g., DNS failure, server down), the app blocks indefinitely on the "Checking for updates..." loading screen because the `autoUpdater` events never fire and the polling promise never resolves.

## Changes
- Added a 10-second timeout to the update check promise so the app continues launching even if the update server is unreachable
- Properly clean up the polling `setInterval` when the update check completes (prevents a minor timer leak in the original code)

## How it works
- If the update check completes normally (success, no-update, or error event), the timeout is cleared and the app proceeds as before
- If 10 seconds pass without any autoUpdater event firing, the timeout resolves the promise and logs a warning, allowing the app to launch in a degraded state (no update applied, but fully functional)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)