### PR TITLE
Add proxy server setting

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -347,7 +347,8 @@ const store = new Conf<StoreSchema>({
       hideToTrayOnClose: false,
       showNotificationOnSongChange: false,
       startOnBoot: false,
-      startMinimized: false
+      startMinimized: false,
+      proxyServer: ""
     },
     appearance: {
       alwaysShowVolumeSlider: false,
@@ -558,6 +559,10 @@ if (store.get("general").disableHardwareAcceleration) {
 
 if (store.get("playback").enableSpeakerFill) {
   app.commandLine.appendSwitch("try-supported-channel-layouts");
+}
+
+if (store.get("general").proxyServer) {
+  app.commandLine.appendSwitch("proxy-server", store.get("general").proxyServer);
 }
 
 function saveState() {

--- a/src/renderer/components/YTMDSetting.vue
+++ b/src/renderer/components/YTMDSetting.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts" generic="T extends 'checkbox' | 'file' | 'range' | 'select' | 'custom'">
+<script setup lang="ts" generic="T extends 'checkbox' | 'file' | 'range' | 'select' | 'custom' | 'text'">
 import { computed, ref } from "vue";
 
 type ModelValue = {
@@ -7,6 +7,7 @@ type ModelValue = {
   range: number;
   custom: never;
   select: number;
+  text: string;
 };
 
 const props = defineProps<{
@@ -206,6 +207,23 @@ input[type="checkbox"]:disabled {
 
 input[type="checkbox"]:disabled::before {
   background-color: #969696;
+}
+
+input[type="text"] {
+  padding: 8px;
+  width: 216px;
+  background-color: #212121;
+  border: none;
+  border-radius: 4px;
+  color: #ffffff;
+}
+
+input[type="text"]:focus {
+  outline: 1px solid #f44336;
+}
+
+input[type="text"]::placeholder {
+  color: #969696;
 }
 
 input[type="file"] {

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -41,6 +41,7 @@ const hideToTrayOnClose = ref<boolean>(general.hideToTrayOnClose);
 const showNotificationOnSongChange = ref<boolean>(general.showNotificationOnSongChange);
 const startOnBoot = ref<boolean>(general.startOnBoot);
 const startMinimized = ref<boolean>(general.startMinimized);
+const proxyServer = ref<string>(general.proxyServer);
 
 const alwaysShowVolumeSlider = ref<boolean>(appearance.alwaysShowVolumeSlider);
 const customCSSEnabled = ref<boolean>(appearance.customCSSEnabled);
@@ -79,6 +80,7 @@ store.onDidAnyChange(async newState => {
   showNotificationOnSongChange.value = newState.general.showNotificationOnSongChange;
   startOnBoot.value = newState.general.startOnBoot;
   startMinimized.value = newState.general.startMinimized;
+  proxyServer.value = newState.general.proxyServer;
 
   alwaysShowVolumeSlider.value = newState.appearance.alwaysShowVolumeSlider;
   customCSSEnabled.value = newState.appearance.customCSSEnabled;
@@ -153,6 +155,7 @@ async function settingsChanged() {
   store.set("general.startOnBoot", startOnBoot.value);
   store.set("general.startMinimized", startMinimized.value);
   store.set("general.disableHardwareAcceleration", disableHardwareAcceleration.value);
+  store.set("general.proxyServer", proxyServer.value);
 
   store.set("appearance.alwaysShowVolumeSlider", alwaysShowVolumeSlider.value);
   store.set("appearance.customCSSEnabled", customCSSEnabled.value);
@@ -297,6 +300,14 @@ window.ytmd.handleUpdateDownloaded(() => {
             type="checkbox"
             restart-required
             name="Disable hardware acceleration"
+            @change="settingChangedRequiresRestart"
+          />
+          <YTMDSetting
+            v-model="proxyServer"
+            type="text"
+            restart-required
+            name="Proxy server"
+            description="Proxy server address (e.g. 127.0.0.1:8080 or http://proxy.example.com:3128)"
             @change="settingChangedRequiresRestart"
           />
         </div>

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -14,6 +14,7 @@ export type StoreSchema = {
     showNotificationOnSongChange: boolean;
     startOnBoot: boolean;
     startMinimized: boolean;
+    proxyServer: string;
   };
   appearance: {
     alwaysShowVolumeSlider: boolean;


### PR DESCRIPTION
## Summary
- Adds a proxy server text input under General settings
- Uses Chromium's built-in `--proxy-server` flag via `app.commandLine.appendSwitch`
- Requires app restart to apply (same pattern as hardware acceleration)
- Adds `text` type support to `YTMDSetting` component

<img width="841" height="627" alt="Screenshot 2026-03-31 at 11 33 12" src="https://github.com/user-attachments/assets/5683d330-f99f-4f7f-9c6e-055b6f9b0e82" />



Closes #178

## Test plan
- [ ] Open Settings > General, verify "Proxy server" field appears with description
- [ ] Enter a bogus proxy (e.g. `127.0.0.1:9999`), tab out, verify restart banner appears
- [ ] Quit and relaunch, verify YouTube Music fails to load (proves flag is applied)
- [ ] Clear the proxy field, quit and relaunch, verify YouTube Music loads normally
- [ ] Optionally test with a real proxy (e.g. tinyproxy) to confirm traffic routes through it

🤖 Generated with [Claude Code](https://claude.com/claude-code)