### PR TITLE
Add ListenBrainz scrobbling integration

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -32,6 +32,7 @@ import CompanionServer from "./integrations/companion-server";
 import CustomCSS from "./integrations/custom-css";
 import DiscordPresence from "./integrations/discord-presence";
 import LastFM from "./integrations/last-fm";
+import ListenBrainz from "./integrations/listenbrainz";
 import NowPlayingNotifications from "./integrations/notifications";
 import VolumeRatio from "./integrations/volume-ratio";
 
@@ -165,6 +166,7 @@ const companionServer = new CompanionServer();
 const customCss = new CustomCSS();
 const discordPresence = new DiscordPresence();
 const lastFMScrobbler = new LastFM();
+const listenBrainzScrobbler = new ListenBrainz();
 const nowPlayingNotifications = new NowPlayingNotifications();
 const ratioVolume = new VolumeRatio();
 
@@ -368,7 +370,8 @@ const store = new Conf<StoreSchema>({
       companionServerAuthTokens: null,
       companionServerCORSWildcardEnabled: false,
       discordPresenceEnabled: false,
-      lastFMEnabled: false
+      lastFMEnabled: false,
+      listenBrainzEnabled: false
     },
     shortcuts: {
       playPause: "",
@@ -392,6 +395,10 @@ const store = new Conf<StoreSchema>({
       secret: "46eea23770a459a49eb4d26cbf46b41c",
       token: null,
       sessionKey: null,
+      scrobblePercent: 50
+    },
+    listenbrainz: {
+      userToken: null,
       scrobblePercent: 50
     },
     developer: {
@@ -546,6 +553,20 @@ store.onDidAnyChange(async (newState, oldState) => {
   } else if (!newState.integrations.lastFMEnabled && oldState.integrations.lastFMEnabled) {
     lastFMScrobbler.disable();
     log.info("Integration disabled: Last.fm");
+  }
+
+  if (newState.integrations.listenBrainzEnabled) {
+    listenBrainzScrobbler.provide(store, memoryStore);
+  }
+  if (newState.integrations.listenBrainzEnabled && !oldState.integrations.listenBrainzEnabled) {
+    listenBrainzScrobbler.enable();
+    log.info("Integration enabled: ListenBrainz");
+  } else if (!newState.integrations.listenBrainzEnabled && oldState.integrations.listenBrainzEnabled) {
+    listenBrainzScrobbler.disable();
+    log.info("Integration disabled: ListenBrainz");
+  }
+  if (newState.listenbrainz.userToken !== oldState.listenbrainz.userToken) {
+    listenBrainzScrobbler.refreshToken();
   }
 
   if (anyShortcutChanged(newState, oldState)) registerShortcuts();
@@ -1951,6 +1972,13 @@ app.on("ready", async () => {
     lastFMScrobbler.provide(store, memoryStore);
     lastFMScrobbler.enable();
     log.info("Integration enabled: Last.fm");
+  }
+
+  // ListenBrainz
+  if (store.get("integrations").listenBrainzEnabled) {
+    listenBrainzScrobbler.provide(store, memoryStore);
+    listenBrainzScrobbler.enable();
+    log.info("Integration enabled: ListenBrainz");
   }
 
   nativeTheme.on("updated", setTrayIcon);

--- a/src/main/integrations/listenbrainz/index.ts
+++ b/src/main/integrations/listenbrainz/index.ts
@@ -1,0 +1,177 @@
+import { safeStorage } from "electron";
+import Conf from "conf";
+
+import playerStateStore, { PlayerState, VideoDetails, VideoState } from "../../player-state-store";
+import MemoryStore from "../../memory-store";
+
+import IIntegration from "../integration";
+import { MemoryStoreSchema, StoreSchema } from "~shared/store/schema";
+import { ListenBrainzSubmitBody } from "./schemas";
+import log from "electron-log";
+
+const LISTENBRAINZ_API_URL = "https://api.listenbrainz.org/1/submit-listens";
+
+export default class ListenBrainz implements IIntegration {
+  private store: Conf<StoreSchema>;
+  private memoryStore: MemoryStore<MemoryStoreSchema>;
+
+  private isEnabled = false;
+
+  private possibleVideoIds: string[] | null;
+  private userToken: string | null = null;
+  private scrobbleTimer: NodeJS.Timeout | null = null;
+  private playerStateFunction: (state: PlayerState) => void;
+
+  // ----------------------------------------------------------
+
+  private async updatePlayerState(state: PlayerState): Promise<void> {
+    if (!this.isEnabled) {
+      return;
+    }
+
+    if (state.videoDetails && state.trackState === VideoState.Playing) {
+      const videoIsPrepped = this.possibleVideoIds && this.possibleVideoIds.indexOf(state.videoDetails.id) !== -1;
+      const queueExists = state.queue && state.queue.items && state.queue.items.length > 0;
+
+      if (videoIsPrepped && queueExists) {
+        return;
+      }
+
+      this.possibleVideoIds = state.queue.items[state.queue.selectedItemIndex]?.counterparts?.map(item => item.videoId) || [];
+      this.possibleVideoIds.push(state.queue.items[state.queue.selectedItemIndex]?.videoId);
+
+      if (!this.userToken) {
+        return;
+      }
+
+      clearTimeout(this.scrobbleTimer);
+
+      // Track must be longer than 30 seconds
+      if (state.videoDetails.durationSeconds < 30) {
+        return;
+      }
+
+      this.updateNowPlaying(state.videoDetails);
+
+      const scrobblePercent = this.store.get("listenbrainz.scrobblePercent");
+      const scrobblePercentDecimal = scrobblePercent / 100;
+      const scrobbleTimeRequired = Math.min(Math.round(state.videoDetails.durationSeconds * scrobblePercentDecimal), 240);
+      const scrobbleTime = new Date().getTime();
+      this.scrobbleTimer = setTimeout(() => {
+        this.scrobbleSong(state.videoDetails, scrobbleTime);
+      }, scrobbleTimeRequired * 1000);
+    }
+  }
+
+  private async updateNowPlaying(videoDetails: VideoDetails): Promise<void> {
+    const body: ListenBrainzSubmitBody = {
+      listen_type: "playing_now",
+      payload: [
+        {
+          track_metadata: {
+            artist_name: videoDetails.author,
+            track_name: videoDetails.title,
+            release_name: videoDetails.album
+          }
+        }
+      ]
+    };
+
+    this.sendToListenBrainz(body);
+  }
+
+  private async scrobbleSong(videoDetails: VideoDetails, scrobbleTime: number): Promise<void> {
+    const body: ListenBrainzSubmitBody = {
+      listen_type: "single",
+      payload: [
+        {
+          listened_at: Math.floor(scrobbleTime / 1000),
+          track_metadata: {
+            artist_name: videoDetails.author,
+            track_name: videoDetails.title,
+            release_name: videoDetails.album
+          }
+        }
+      ]
+    };
+
+    this.sendToListenBrainz(body);
+  }
+
+  private async sendToListenBrainz(body: ListenBrainzSubmitBody): Promise<void> {
+    try {
+      const response = await fetch(LISTENBRAINZ_API_URL, {
+        method: "POST",
+        headers: {
+          "Authorization": `Token ${this.userToken}`,
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(body)
+      });
+
+      if (response.status === 401) {
+        log.warn("ListenBrainz: Invalid user token. Please update your token in settings.");
+      } else if (!response.ok) {
+        log.error(`ListenBrainz: API error ${response.status}: ${response.statusText}`);
+      }
+    } catch (error) {
+      log.error("ListenBrainz: Failed to send request", error);
+    }
+  }
+
+  // ----------------------------------------------------------
+
+  public provide(store: Conf<StoreSchema>, memoryStore: MemoryStore<MemoryStoreSchema>): void {
+    this.store = store;
+    this.memoryStore = memoryStore;
+  }
+
+  public enable(): void {
+    if (!this.memoryStore.get("safeStorageAvailable")) {
+      log.info("Refusing to enable ListenBrainz Integration with reason: safeStorage unavailable");
+      return;
+    }
+
+    if (this.isEnabled) {
+      return;
+    }
+    this.isEnabled = true;
+
+    this.userToken = this.getToken();
+
+    this.playerStateFunction = (state: PlayerState) => this.updatePlayerState(state);
+    playerStateStore.addEventListener(this.playerStateFunction);
+  }
+
+  public disable(): void {
+    if (!this.isEnabled) {
+      return;
+    }
+
+    clearTimeout(this.scrobbleTimer);
+    playerStateStore.removeEventListener(this.playerStateFunction);
+    this.isEnabled = false;
+  }
+
+  public refreshToken(): void {
+    this.userToken = this.getToken();
+  }
+
+  public getYTMScripts(): { name: string; script: string }[] {
+    return [];
+  }
+
+  private getToken(): string | null {
+    const encryptedToken = this.store.get("listenbrainz.userToken");
+    if (!encryptedToken) {
+      return null;
+    }
+
+    try {
+      return safeStorage.decryptString(Buffer.from(encryptedToken, "hex"));
+    } catch (e) {
+      log.error("ListenBrainz: Failed to decrypt user token", e);
+      return null;
+    }
+  }
+}

--- a/src/main/integrations/listenbrainz/schemas.ts
+++ b/src/main/integrations/listenbrainz/schemas.ts
@@ -1,0 +1,22 @@
+export type ListenBrainzTrackMetadata = {
+  artist_name: string;
+  track_name: string;
+  release_name?: string;
+};
+
+export type ListenBrainzPayloadItem = {
+  listened_at?: number;
+  track_metadata: ListenBrainzTrackMetadata;
+};
+
+export type ListenBrainzSubmitBody = {
+  listen_type: "playing_now" | "single";
+  payload: ListenBrainzPayloadItem[];
+};
+
+export type ListenBrainzValidateTokenResponse = {
+  code: number;
+  message: string;
+  valid: boolean;
+  user_name?: string;
+};

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -35,6 +35,7 @@ const playback: StoreSchema["playback"] = await store.get("playback");
 const integrations: StoreSchema["integrations"] = await store.get("integrations");
 const shortcuts: StoreSchema["shortcuts"] = await store.get("shortcuts");
 const lastFM: StoreSchema["lastfm"] = await store.get("lastfm");
+const listenBrainzStore: StoreSchema["listenbrainz"] = await store.get("listenbrainz");
 
 const disableHardwareAcceleration = ref<boolean>(general.disableHardwareAcceleration);
 const hideToTrayOnClose = ref<boolean>(general.hideToTrayOnClose);
@@ -61,6 +62,10 @@ const companionServerAuthTokens = ref<AuthToken[]>(
 const companionServerCORSWildcardEnabled = ref<boolean>(integrations.companionServerCORSWildcardEnabled);
 const discordPresenceEnabled = ref<boolean>(integrations.discordPresenceEnabled);
 const lastFMEnabled = ref<boolean>(integrations.lastFMEnabled);
+const listenBrainzEnabled = ref<boolean>(integrations.listenBrainzEnabled);
+const listenBrainzAuthenticated = ref<boolean>(!!listenBrainzStore.userToken);
+const listenBrainzTokenInput = ref<string>("");
+const listenBrainzScrobblePercent = ref<number>(listenBrainzStore.scrobblePercent);
 
 const shortcutPlayPause = ref<string>(shortcuts.playPause);
 const shortcutNext = ref<string>(shortcuts.next);
@@ -101,6 +106,10 @@ store.onDidAnyChange(async newState => {
   lastFMEnabled.value = newState.integrations.lastFMEnabled;
   lastFMSessionKey.value = newState.lastfm.sessionKey;
   scrobblePercent.value = newState.lastfm.scrobblePercent;
+
+  listenBrainzEnabled.value = newState.integrations.listenBrainzEnabled;
+  listenBrainzAuthenticated.value = !!newState.listenbrainz.userToken;
+  listenBrainzScrobblePercent.value = newState.listenbrainz.scrobblePercent;
 
   shortcutPlayPause.value = newState.shortcuts.playPause;
   shortcutNext.value = newState.shortcuts.next;
@@ -170,6 +179,8 @@ async function settingsChanged() {
   store.set("integrations.discordPresenceEnabled", discordPresenceEnabled.value);
   store.set("integrations.lastFMEnabled", lastFMEnabled.value);
   store.set("lastfm.scrobblePercent", scrobblePercent.value);
+  store.set("integrations.listenBrainzEnabled", listenBrainzEnabled.value);
+  store.set("listenbrainz.scrobblePercent", listenBrainzScrobblePercent.value);
 
   store.set("shortcuts.playPause", shortcutPlayPause.value);
   store.set("shortcuts.next", shortcutNext.value);
@@ -240,6 +251,22 @@ async function logoutLastFM() {
   store.set("lastfm.sessionKey", null);
   lastFMEnabled.value = false;
   lastFMSessionKey.value = null;
+  await settingsChanged();
+}
+
+async function saveListenBrainzToken() {
+  if (!listenBrainzTokenInput.value.trim()) return;
+  const encrypted = await safeStorage.encryptString(listenBrainzTokenInput.value.trim());
+  store.set("listenbrainz.userToken", encrypted);
+  listenBrainzTokenInput.value = "";
+  listenBrainzAuthenticated.value = true;
+  await settingsChanged();
+}
+
+async function logoutListenBrainz() {
+  store.set("listenbrainz.userToken", null);
+  listenBrainzEnabled.value = false;
+  listenBrainzAuthenticated.value = false;
   await settingsChanged();
 }
 
@@ -428,6 +455,46 @@ window.ytmd.handleUpdateDownloaded(() => {
           <YTMDSetting
             v-if="lastFMEnabled"
             v-model="scrobblePercent"
+            class="settings indented"
+            type="range"
+            name="Scrobble percent"
+            description="Determines when a song is scrobbled"
+            min="50"
+            max="95"
+            step="5"
+            @change="settingsChanged"
+          />
+          <YTMDSetting
+            v-model="listenBrainzEnabled"
+            type="checkbox"
+            name="ListenBrainz scrobbling"
+            :disabled="!safeStorageAvailable"
+            disabled-message="This integration cannot be enabled due to safeStorage being unavailable"
+            @change="settingsChanged"
+          />
+          <div v-if="listenBrainzEnabled" class="setting indented">
+            <div class="name-with-description">
+              <p class="description">
+                User is Authenticated:
+                <span v-if="listenBrainzAuthenticated" style="color: #4caf50">Yes</span>
+                <span v-else style="color: #ff1100">No</span>
+              </p>
+            </div>
+            <button v-if="listenBrainzAuthenticated" @click="logoutListenBrainz">Logout</button>
+          </div>
+          <div v-if="listenBrainzEnabled && !listenBrainzAuthenticated" class="setting indented">
+            <div class="name-with-description">
+              <p class="name">User token</p>
+              <p class="description">Get your token from listenbrainz.org/settings/</p>
+            </div>
+            <div class="listenbrainz-token-input">
+              <input v-model="listenBrainzTokenInput" type="text" placeholder="Paste your token here" />
+              <button @click="saveListenBrainzToken">Save</button>
+            </div>
+          </div>
+          <YTMDSetting
+            v-if="listenBrainzEnabled"
+            v-model="listenBrainzScrobblePercent"
             class="settings indented"
             type="range"
             name="Scrobble percent"
@@ -866,5 +933,28 @@ button {
 .shortcuts-tab .shortcut-title .register-error {
   margin-left: 4px;
   color: #f44336;
+}
+
+.listenbrainz-token-input {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.listenbrainz-token-input input[type="text"] {
+  padding: 8px;
+  width: 180px;
+  background-color: #212121;
+  border: none;
+  border-radius: 4px;
+  color: #ffffff;
+}
+
+.listenbrainz-token-input input[type="text"]:focus {
+  outline: 1px solid #f44336;
+}
+
+.listenbrainz-token-input input[type="text"]::placeholder {
+  color: #969696;
 }
 </style>

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -35,6 +35,7 @@ export type StoreSchema = {
     companionServerCORSWildcardEnabled: boolean;
     discordPresenceEnabled: boolean;
     lastFMEnabled: boolean;
+    listenBrainzEnabled: boolean;
   };
   shortcuts: {
     playPause: string;
@@ -57,6 +58,10 @@ export type StoreSchema = {
     secret: string;
     token: string | null;
     sessionKey: string | null;
+    scrobblePercent: number;
+  };
+  listenbrainz: {
+    userToken: string | null;
     scrobblePercent: number;
   };
   developer: {


### PR DESCRIPTION
## Summary
- Adds ListenBrainz as a scrobbling option alongside Last.fm
- Token-based auth (user provides token from listenbrainz.org/settings/)
- Supports now-playing updates and scrobbling with configurable scrobble percent
- Token encrypted via safeStorage (same pattern as Last.fm)
- Mirrors the existing Last.fm integration architecture exactly

<img width="834" height="618" alt="Screenshot 2026-03-31 at 11 38 56" src="https://github.com/user-attachments/assets/05732f8c-6114-4e0e-868a-63e72c26554d" />


<img width="824" height="624" alt="Screenshot 2026-03-31 at 11 38 32" src="https://github.com/user-attachments/assets/2e71e1db-a4e5-424f-a7ff-5f9e750a8731" />


Closes #257

## Test plan
- [ ] Open Settings > Integrations, verify "ListenBrainz scrobbling" toggle appears
- [ ] Enable it, verify token input field appears
- [ ] Paste a valid token from listenbrainz.org/settings/, click Save
- [ ] Verify auth status shows "Yes"
- [ ] Play a song longer than 30 seconds
- [ ] Check listenbrainz.org/user/<username>/ for the scrobble
- [ ] Click Logout, verify token is cleared and auth status shows "No"
- [ ] Adjust scrobble percent, verify new threshold is used
- [ ] Enable both Last.fm and ListenBrainz simultaneously, verify both work independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)