### PR TITLE
Add Play Supermix shortcut and tray button

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -328,6 +328,7 @@ function anyShortcutChanged(newState: Readonly<StoreSchema>, oldState: Readonly<
   if (newState.shortcuts.thumbsUp !== oldState.shortcuts.thumbsUp) return true;
   if (newState.shortcuts.volumeDown !== oldState.shortcuts.volumeDown) return true;
   if (newState.shortcuts.volumeUp !== oldState.shortcuts.volumeUp) return true;
+  if (newState.shortcuts.playSupermix !== oldState.shortcuts.playSupermix) return true;
 
   return false;
 }
@@ -377,14 +378,16 @@ const store = new Conf<StoreSchema>({
       thumbsUp: "",
       thumbsDown: "",
       volumeUp: "",
-      volumeDown: ""
+      volumeDown: "",
+      playSupermix: ""
     },
     state: {
       lastUrl: "https://music.youtube.com/",
       lastPlaylistId: "",
       lastVideoId: "",
       windowBounds: null,
-      windowMaximized: false
+      windowMaximized: false,
+      supermixPlaylistId: ""
     },
     lastfm: {
       // Last FM Keys belong to @Alipoodle
@@ -863,6 +866,29 @@ function registerShortcuts() {
     }
   } else {
     memoryStore.set("shortcutsVolumeDownRegisterFailed", false);
+  }
+
+  if (shortcuts.playSupermix) {
+    let registered = false;
+    try {
+      registered = globalShortcut.register(shortcuts.playSupermix, () => {
+        if (ytmView) {
+          ytmView.webContents.send("remoteControl:execute", "playSupermix");
+        }
+      });
+    } catch {
+      /* empty */
+    }
+
+    if (!registered) {
+      log.info("Failed to register shortcut: playSupermix");
+      memoryStore.set("shortcutsPlaySupermixRegisterFailed", true);
+    } else {
+      log.info("Registered shortcut: playSupermix");
+      memoryStore.set("shortcutsPlaySupermixRegisterFailed", false);
+    }
+  } else {
+    memoryStore.set("shortcutsPlaySupermixRegisterFailed", false);
   }
 
   log.info("Registered shortcuts");
@@ -1845,6 +1871,17 @@ app.on("ready", async () => {
       type: "normal",
       click: () => {
         ytmView.webContents.send("remoteControl:execute", "next");
+      }
+    },
+    {
+      label: store.get("shortcuts").playSupermix
+        ? `Play Supermix (${store.get("shortcuts").playSupermix.replace("Meta", isDarwin ? "Cmd" : "Win")})`
+        : "Play Supermix",
+      type: "normal",
+      click: () => {
+        if (ytmView) {
+          ytmView.webContents.send("remoteControl:execute", "playSupermix");
+        }
       }
     },
     {

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -69,6 +69,7 @@ const shortcutThumbsUp = ref<string>(shortcuts.thumbsUp);
 const shortcutThumbsDown = ref<string>(shortcuts.thumbsDown);
 const shortcutVolumeUp = ref<string>(shortcuts.volumeUp);
 const shortcutVolumeDown = ref<string>(shortcuts.volumeDown);
+const shortcutPlaySupermix = ref<string>(shortcuts.playSupermix);
 
 const lastFMSessionKey = ref<string>(lastFM.sessionKey);
 const scrobblePercent = ref<number>(lastFM.scrobblePercent);
@@ -109,6 +110,7 @@ store.onDidAnyChange(async newState => {
   shortcutThumbsDown.value = newState.shortcuts.thumbsDown;
   shortcutVolumeUp.value = newState.shortcuts.volumeUp;
   shortcutVolumeDown.value = newState.shortcuts.volumeDown;
+  shortcutPlaySupermix.value = newState.shortcuts.playSupermix;
 });
 
 const discordPresenceConnectionFailed = ref<boolean>(await memoryStore.get("discordPresenceConnectionFailed"));
@@ -120,6 +122,7 @@ const shortcutsThumbsUpRegisterFailed = ref<boolean>(await memoryStore.get("shor
 const shortcutsThumbsDownRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsThumbsDownRegisterFailed"));
 const shortcutsVolumeUpRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsVolumeUpRegisterFailed"));
 const shortcutsVolumeDownRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsVolumeDownRegisterFailed"));
+const shortcutsPlaySupermixRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsPlaySupermixRegisterFailed"));
 
 const companionServerAuthWindowEnabled = ref<boolean>(await memoryStore.get("companionServerAuthWindowEnabled"));
 
@@ -135,6 +138,7 @@ memoryStore.onStateChanged(newState => {
   shortcutsThumbsDownRegisterFailed.value = newState.shortcutsThumbsDownRegisterFailed;
   shortcutsVolumeUpRegisterFailed.value = newState.shortcutsVolumeUpRegisterFailed;
   shortcutsVolumeDownRegisterFailed.value = newState.shortcutsVolumeDownRegisterFailed;
+  shortcutsPlaySupermixRegisterFailed.value = newState.shortcutsPlaySupermixRegisterFailed;
 
   companionServerAuthWindowEnabled.value = newState.companionServerAuthWindowEnabled;
 
@@ -178,6 +182,7 @@ async function settingsChanged() {
   store.set("shortcuts.thumbsDown", shortcutThumbsDown.value);
   store.set("shortcuts.volumeUp", shortcutVolumeUp.value);
   store.set("shortcuts.volumeDown", shortcutVolumeDown.value);
+  store.set("shortcuts.playSupermix", shortcutPlaySupermix.value);
 }
 
 async function settingChangedRequiresRestart() {
@@ -516,6 +521,17 @@ window.ytmd.handleUpdateDownloaded(() => {
               >
             </p>
             <KeybindInput v-model="shortcutVolumeDown" @change="settingsChanged" />
+          </div>
+          <div class="setting">
+            <p class="shortcut-title">
+              Play Supermix<span
+                v-if="shortcutsPlaySupermixRegisterFailed"
+                class="material-symbols-outlined register-error"
+                title="Failed to register keybind. Does another application have this keybind?"
+                >error</span
+              >
+            </p>
+            <KeybindInput v-model="shortcutPlaySupermix" @change="settingsChanged" />
           </div>
         </div>
 

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -581,6 +581,22 @@ window.addEventListener("load", async () => {
         );
         break;
       }
+
+      case "playSupermix": {
+        const supermixState = await store.get("state");
+        const playlistId = supermixState.supermixPlaylistId;
+        if (playlistId) {
+          window.location.href = `https://music.youtube.com/playlist?list=${playlistId}`;
+        }
+        break;
+      }
+
+      case "playMix": {
+        if (value) {
+          window.location.href = `https://music.youtube.com/playlist?list=${value}`;
+        }
+        break;
+      }
     }
   });
 
@@ -610,6 +626,57 @@ window.addEventListener("load", async () => {
         volumeSlider.classList.remove("ytmd-persist-volume-slider");
       }
     }
+  });
+
+  // Scan for Supermix playlist ID and save to store
+  async function scanForSupermix(): Promise<boolean> {
+    const playlistId: string | null = (
+      await webFrame.executeJavaScript(`
+        (function() {
+          const items = document.querySelectorAll("ytmusic-two-row-item-renderer");
+          for (const item of items) {
+            const titleEl = item.querySelector("yt-formatted-string.title");
+            if (!titleEl) continue;
+            if (titleEl.textContent.trim() === "My Supermix") {
+              const link = item.querySelector("a.yt-simple-endpoint");
+              if (link) {
+                const href = link.getAttribute("href");
+                const match = href && href.match(/[?&]list=([^&]+)/);
+                if (match) return match[1];
+              }
+            }
+          }
+          return null;
+        })
+      `)
+    )();
+
+    if (playlistId) {
+      store.set("state.supermixPlaylistId", playlistId);
+      return true;
+    }
+    return false;
+  }
+
+  // Scan periodically after page loads to catch the home page carousel
+  let supermixScanInterval: NodeJS.Timeout | null = null;
+  function startSupermixScan() {
+    if (supermixScanInterval) clearInterval(supermixScanInterval);
+    let attempts = 0;
+    supermixScanInterval = setInterval(async () => {
+      attempts++;
+      const found = await scanForSupermix();
+      if (found || attempts >= 10) {
+        clearInterval(supermixScanInterval);
+        supermixScanInterval = null;
+      }
+    }, 1000);
+  }
+
+  // Run scan on initial load and on navigation
+  startSupermixScan();
+  window.addEventListener("yt-navigate-finish", () => {
+    startSupermixScan();
   });
 
   ipcRenderer.on("ytmView:refitPopups", async () => {

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -44,6 +44,7 @@ export type StoreSchema = {
     thumbsDown: string;
     volumeUp: string;
     volumeDown: string;
+    playSupermix: string;
   };
   state: {
     lastUrl: string;
@@ -51,6 +52,7 @@ export type StoreSchema = {
     lastVideoId: string;
     windowBounds: Electron.Rectangle | null;
     windowMaximized: boolean;
+    supermixPlaylistId: string;
   };
   lastfm: {
     api_key: string;
@@ -73,6 +75,7 @@ export type MemoryStoreSchema = {
   shortcutsThumbsDownRegisterFailed: boolean;
   shortcutsVolumeUpRegisterFailed: boolean;
   shortcutsVolumeDownRegisterFailed: boolean;
+  shortcutsPlaySupermixRegisterFailed: boolean;
   companionServerAuthWindowEnabled: boolean;
   safeStorageAvailable: boolean;
   autoUpdaterDisabled: boolean;


### PR DESCRIPTION
## Summary

Adds a way to quickly start playing the user's "My Supermix" personalized mix from anywhere in the app, without needing to navigate to the home page first.

This addresses the original request in #328 for a "Your Mix" shortcut. "Your Mix" no longer exists in YouTube Music, but "My Supermix" is its replacement.

## How it works

### Entry points
1. **Global keyboard shortcut** - Configurable in Settings > Shortcuts as "Play Supermix". User sets their own keybind.
2. **Tray menu button** - "Play Supermix" appears in the system tray context menu. If a shortcut is configured, it's shown in the label (e.g. "Play Supermix (Cmd+M)").

### Technical flow
1. **Supermix ID discovery** - On app startup and on each `yt-navigate-finish` event, a background scanner runs up to 10 attempts (1 second apart) querying the YouTube Music DOM for a `ytmusic-two-row-item-renderer` with title "My Supermix". When found, the playlist ID is extracted from the element's `href` attribute and saved to the persistent config store (`state.supermixPlaylistId`).
2. **Playback trigger** - When the shortcut or tray button is pressed, the `playSupermix` remote control command reads the stored playlist ID and navigates directly to `https://music.youtube.com/playlist?list={id}`. This works from any page since it uses a full URL navigation, not a DOM click.
3. **ID refresh** - The scanner runs on every page navigation, so the playlist ID stays current if YouTube Music changes it.

### Files changed
- `src/shared/store/schema.ts` - Added `playSupermix` shortcut, `supermixPlaylistId` state, `shortcutsPlaySupermixRegisterFailed` memory flag
- `src/main/index.ts` - Shortcut registration, tray menu button, store defaults
- `src/renderer/ytmview/preload.ts` - `playSupermix` and `playMix` remote control commands, background Supermix ID scanner
- `src/renderer/windows/settings/Settings.vue` - Shortcut keybind UI in Settings > Shortcuts

## Important notes

- **First visit required** - The user must visit the YouTube Music home page at least once for the scanner to discover the Supermix playlist ID. The app starts on the home page by default, so this happens automatically in most cases. Once discovered, the ID is persisted and the feature works from any page, including across app restarts.
- **DOM fragility** - The Supermix ID scanner relies on querying YouTube Music's DOM for elements with the title "My Supermix". If Google changes the element structure, class names, or title text, the scanner would stop finding the ID. This is the same level of DOM dependency as the existing like/dislike shortcuts. Once an ID is found and saved, playback continues to work until the playlist ID itself changes.

## Performance

The background scanner runs at most 10 times per page navigation (1 second intervals), each scan doing a single `querySelectorAll` + loop. This is lightweight and stops as soon as the ID is found (typically on the first attempt when on the home page). No polling occurs outside of page navigation events.

Closes #328

## Test plan
- [ ] Open Settings > Shortcuts, set a keybind for "Play Supermix"
- [ ] Navigate to a non-home page (e.g. search, library)
- [ ] Press the keybind, verify it navigates to and starts playing the Supermix
- [ ] Click "Play Supermix" from the system tray menu, verify same behavior
- [ ] Verify the tray label shows the configured keybind (e.g. "Play Supermix (Cmd+M)")
- [ ] Restart the app, verify the Supermix still works without visiting the home page first (cached ID)
- [ ] Visit the home page, verify the scanner updates the ID (check config.json for `supermixPlaylistId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)