### PR TITLE
Add navigate back/forward keyboard shortcuts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -328,6 +328,8 @@ function anyShortcutChanged(newState: Readonly<StoreSchema>, oldState: Readonly<
   if (newState.shortcuts.thumbsUp !== oldState.shortcuts.thumbsUp) return true;
   if (newState.shortcuts.volumeDown !== oldState.shortcuts.volumeDown) return true;
   if (newState.shortcuts.volumeUp !== oldState.shortcuts.volumeUp) return true;
+  if (newState.shortcuts.navigateBack !== oldState.shortcuts.navigateBack) return true;
+  if (newState.shortcuts.navigateForward !== oldState.shortcuts.navigateForward) return true;
 
   return false;
 }
@@ -377,7 +379,9 @@ const store = new Conf<StoreSchema>({
       thumbsUp: "",
       thumbsDown: "",
       volumeUp: "",
-      volumeDown: ""
+      volumeDown: "",
+      navigateBack: "",
+      navigateForward: ""
     },
     state: {
       lastUrl: "https://music.youtube.com/",
@@ -863,6 +867,52 @@ function registerShortcuts() {
     }
   } else {
     memoryStore.set("shortcutsVolumeDownRegisterFailed", false);
+  }
+
+  if (shortcuts.navigateBack) {
+    let registered = false;
+    try {
+      registered = globalShortcut.register(shortcuts.navigateBack, () => {
+        if (ytmView && ytmView.webContents.navigationHistory.canGoBack()) {
+          ytmView.webContents.navigationHistory.goBack();
+        }
+      });
+    } catch {
+      /* empty */
+    }
+
+    if (!registered) {
+      log.info("Failed to register shortcut: navigateBack");
+      memoryStore.set("shortcutsNavigateBackRegisterFailed", true);
+    } else {
+      log.info("Registered shortcut: navigateBack");
+      memoryStore.set("shortcutsNavigateBackRegisterFailed", false);
+    }
+  } else {
+    memoryStore.set("shortcutsNavigateBackRegisterFailed", false);
+  }
+
+  if (shortcuts.navigateForward) {
+    let registered = false;
+    try {
+      registered = globalShortcut.register(shortcuts.navigateForward, () => {
+        if (ytmView && ytmView.webContents.navigationHistory.canGoForward()) {
+          ytmView.webContents.navigationHistory.goForward();
+        }
+      });
+    } catch {
+      /* empty */
+    }
+
+    if (!registered) {
+      log.info("Failed to register shortcut: navigateForward");
+      memoryStore.set("shortcutsNavigateForwardRegisterFailed", true);
+    } else {
+      log.info("Registered shortcut: navigateForward");
+      memoryStore.set("shortcutsNavigateForwardRegisterFailed", false);
+    }
+  } else {
+    memoryStore.set("shortcutsNavigateForwardRegisterFailed", false);
   }
 
   log.info("Registered shortcuts");

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -69,6 +69,8 @@ const shortcutThumbsUp = ref<string>(shortcuts.thumbsUp);
 const shortcutThumbsDown = ref<string>(shortcuts.thumbsDown);
 const shortcutVolumeUp = ref<string>(shortcuts.volumeUp);
 const shortcutVolumeDown = ref<string>(shortcuts.volumeDown);
+const shortcutNavigateBack = ref<string>(shortcuts.navigateBack);
+const shortcutNavigateForward = ref<string>(shortcuts.navigateForward);
 
 const lastFMSessionKey = ref<string>(lastFM.sessionKey);
 const scrobblePercent = ref<number>(lastFM.scrobblePercent);
@@ -109,6 +111,8 @@ store.onDidAnyChange(async newState => {
   shortcutThumbsDown.value = newState.shortcuts.thumbsDown;
   shortcutVolumeUp.value = newState.shortcuts.volumeUp;
   shortcutVolumeDown.value = newState.shortcuts.volumeDown;
+  shortcutNavigateBack.value = newState.shortcuts.navigateBack;
+  shortcutNavigateForward.value = newState.shortcuts.navigateForward;
 });
 
 const discordPresenceConnectionFailed = ref<boolean>(await memoryStore.get("discordPresenceConnectionFailed"));
@@ -120,6 +124,8 @@ const shortcutsThumbsUpRegisterFailed = ref<boolean>(await memoryStore.get("shor
 const shortcutsThumbsDownRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsThumbsDownRegisterFailed"));
 const shortcutsVolumeUpRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsVolumeUpRegisterFailed"));
 const shortcutsVolumeDownRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsVolumeDownRegisterFailed"));
+const shortcutsNavigateBackRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsNavigateBackRegisterFailed"));
+const shortcutsNavigateForwardRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsNavigateForwardRegisterFailed"));
 
 const companionServerAuthWindowEnabled = ref<boolean>(await memoryStore.get("companionServerAuthWindowEnabled"));
 
@@ -135,6 +141,8 @@ memoryStore.onStateChanged(newState => {
   shortcutsThumbsDownRegisterFailed.value = newState.shortcutsThumbsDownRegisterFailed;
   shortcutsVolumeUpRegisterFailed.value = newState.shortcutsVolumeUpRegisterFailed;
   shortcutsVolumeDownRegisterFailed.value = newState.shortcutsVolumeDownRegisterFailed;
+  shortcutsNavigateBackRegisterFailed.value = newState.shortcutsNavigateBackRegisterFailed;
+  shortcutsNavigateForwardRegisterFailed.value = newState.shortcutsNavigateForwardRegisterFailed;
 
   companionServerAuthWindowEnabled.value = newState.companionServerAuthWindowEnabled;
 
@@ -178,6 +186,8 @@ async function settingsChanged() {
   store.set("shortcuts.thumbsDown", shortcutThumbsDown.value);
   store.set("shortcuts.volumeUp", shortcutVolumeUp.value);
   store.set("shortcuts.volumeDown", shortcutVolumeDown.value);
+  store.set("shortcuts.navigateBack", shortcutNavigateBack.value ?? "");
+  store.set("shortcuts.navigateForward", shortcutNavigateForward.value ?? "");
 }
 
 async function settingChangedRequiresRestart() {
@@ -516,6 +526,28 @@ window.ytmd.handleUpdateDownloaded(() => {
               >
             </p>
             <KeybindInput v-model="shortcutVolumeDown" @change="settingsChanged" />
+          </div>
+          <div class="setting">
+            <p class="shortcut-title">
+              Navigate Back<span
+                v-if="shortcutsNavigateBackRegisterFailed"
+                class="material-symbols-outlined register-error"
+                title="Failed to register keybind. Does another application have this keybind?"
+                >error</span
+              >
+            </p>
+            <KeybindInput v-model="shortcutNavigateBack" @change="settingsChanged" />
+          </div>
+          <div class="setting">
+            <p class="shortcut-title">
+              Navigate Forward<span
+                v-if="shortcutsNavigateForwardRegisterFailed"
+                class="material-symbols-outlined register-error"
+                title="Failed to register keybind. Does another application have this keybind?"
+                >error</span
+              >
+            </p>
+            <KeybindInput v-model="shortcutNavigateForward" @change="settingsChanged" />
           </div>
         </div>
 

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -44,6 +44,8 @@ export type StoreSchema = {
     thumbsDown: string;
     volumeUp: string;
     volumeDown: string;
+    navigateBack: string;
+    navigateForward: string;
   };
   state: {
     lastUrl: string;
@@ -73,6 +75,8 @@ export type MemoryStoreSchema = {
   shortcutsThumbsDownRegisterFailed: boolean;
   shortcutsVolumeUpRegisterFailed: boolean;
   shortcutsVolumeDownRegisterFailed: boolean;
+  shortcutsNavigateBackRegisterFailed: boolean;
+  shortcutsNavigateForwardRegisterFailed: boolean;
   companionServerAuthWindowEnabled: boolean;
   safeStorageAvailable: boolean;
   autoUpdaterDisabled: boolean;


### PR DESCRIPTION
## Summary
- Adds configurable **Navigate Back** and **Navigate Forward** global keyboard shortcuts (e.g. Cmd+Left/Right on Mac, Alt+Left/Right on Windows/Linux)
- New entries appear in Settings > Shortcuts, following the existing shortcut pattern
- Uses Electron's `navigationHistory.goBack()`/`goForward()` on the ytmView webContents

<img width="802" height="605" alt="Screenshot 2026-03-31 at 11 45 28" src="https://github.com/user-attachments/assets/1a9e95ca-51cf-43d5-9c01-d37801473f5e" />

Closes #365

## Test plan
- [ ] Open Settings > Shortcuts, verify "Navigate Back" and "Navigate Forward" appear
- [ ] Bind shortcuts (e.g. Cmd+Left, Cmd+Right) and navigate between YTM pages
- [ ] Verify clearing a shortcut does not crash (guard against undefined values)
- [ ] Verify error icon appears when binding a conflicting key

🤖 Generated with [Claude Code](https://claude.com/claude-code)