### PR TITLE
Add preset theme selector with built-in themes

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -31,7 +31,9 @@ const config: ForgeConfig = {
       "./src/assets/icons/controls/pause-button.png",
       "./src/assets/icons/controls/play-button.png",
       "./src/assets/icons/controls/play-next-button.png",
-      "./src/assets/icons/controls/play-previous-button.png"
+      "./src/assets/icons/controls/play-previous-button.png",
+
+      "./src/assets/custom-css-template.css"
     ],
     protocols: [
       {

--- a/src/assets/custom-css-template.css
+++ b/src/assets/custom-css-template.css
@@ -1,0 +1,283 @@
+/*
+ * YouTube Music Desktop - Custom CSS Template
+ * =============================================
+ *
+ * This template documents the main CSS selectors you can use to customize
+ * YouTube Music's appearance. Uncomment and modify any section below.
+ *
+ * TIPS:
+ * - Use !important to override YouTube Music's built-in styles
+ * - Custom CSS layers ON TOP of any preset theme you've selected
+ * - Changes are applied in real-time when you save this file
+ * - If YouTube Music updates and breaks your styles, you may need to
+ *   inspect the page (Ctrl+Shift+I / Cmd+Option+I with DevTools enabled)
+ *   to find updated selectors
+ *
+ * GETTING STARTED:
+ * 1. Save this file somewhere on your computer
+ * 2. Go to Settings > Appearance
+ * 3. Enable "Custom CSS" and select this file
+ * 4. Edit and save this file - changes apply instantly
+ */
+
+
+/* ===========================================
+ * CSS CUSTOM PROPERTIES (recommended approach)
+ * ===========================================
+ * Override these on ytmusic-app to change colors globally.
+ * This is the safest method as YouTube Music reads these variables.
+ */
+
+/*
+ytmusic-app {
+  --ytmusic-general-background-a: #1a1a2e !important;
+  --ytmusic-general-background-b: #16213e !important;
+  --ytmusic-general-background-c: #0f3460 !important;
+  --ytmusic-brand-background-solid: #1a1a2e !important;
+  --ytmusic-text-primary: #e0e0e0 !important;
+  --ytmusic-text-secondary: #a0a0a0 !important;
+  --ytmusic-color-white1: #e0e0e0 !important;
+  --ytmusic-color-white2: #a0a0a0 !important;
+  --ytmusic-color-white3: #a0a0a0 !important;
+  --ytmusic-color-white4: #a0a0a0 !important;
+  --ytmusic-selected-indicator-color: #e94560 !important;
+}
+*/
+
+
+/* ===========================================
+ * MAIN LAYOUT
+ * ===========================================
+ */
+
+/* Page background (behind all content) */
+/*
+html, body {
+  background-color: #1a1a2e !important;
+}
+*/
+
+/* Main content panel */
+/*
+#layout,
+#main-panel,
+ytmusic-browse-response,
+ytmusic-search-page {
+  background-color: #1a1a2e !important;
+}
+*/
+
+
+/* ===========================================
+ * PLAYER BAR (bottom bar with playback controls)
+ * ===========================================
+ */
+
+/* Player bar background */
+/*
+ytmusic-player-bar,
+#player-bar-background {
+  background: #16213e !important;
+}
+*/
+
+/* Song title in player bar */
+/*
+ytmusic-player-bar .title yt-formatted-string {
+  color: #ffffff !important;
+}
+*/
+
+/* Artist/album text in player bar */
+/*
+ytmusic-player-bar .byline yt-formatted-string {
+  color: #a0a0a0 !important;
+}
+*/
+
+/* Playback control buttons (play, next, prev, etc.) */
+/*
+ytmusic-player-bar tp-yt-paper-icon-button {
+  color: #e0e0e0 !important;
+}
+*/
+
+/* Time display (e.g., "1:23 / 4:56") */
+/*
+ytmusic-player-bar .time-info {
+  color: #a0a0a0 !important;
+}
+*/
+
+
+/* ===========================================
+ * NAVIGATION & HEADER
+ * ===========================================
+ */
+
+/* Top navigation bar */
+/*
+#nav-bar-background,
+ytmusic-pivot-bar-renderer {
+  background: #1a1a2e !important;
+}
+*/
+
+/* Header area */
+/*
+ytmusic-header-renderer,
+#header-bar {
+  background: #1a1a2e !important;
+}
+*/
+
+/* Side navigation drawer */
+/*
+tp-yt-app-drawer#guide-wrapper {
+  background: #16213e !important;
+}
+*/
+
+/* Navigation tabs (Home, Explore, Library, etc.) */
+/*
+tp-yt-paper-tab {
+  color: #a0a0a0 !important;
+}
+
+tp-yt-paper-tab[aria-selected="true"] {
+  color: #ffffff !important;
+}
+*/
+
+
+/* ===========================================
+ * SEARCH
+ * ===========================================
+ */
+
+/* Search box container */
+/*
+ytmusic-search-box[is-bauhaus-sidenav-enabled] .search-container {
+  background: #16213e !important;
+  border-color: #0f3460 !important;
+}
+*/
+
+/* Search input text */
+/*
+ytmusic-search-box input.style-scope {
+  color: #e0e0e0 !important;
+}
+*/
+
+
+/* ===========================================
+ * CONTENT ITEMS (songs, albums, playlists)
+ * ===========================================
+ */
+
+/* Song list items */
+/*
+ytmusic-responsive-list-item-renderer {
+  color: #e0e0e0 !important;
+}
+*/
+
+/* Hover state on list items */
+/*
+ytmusic-responsive-list-item-renderer:hover {
+  background: #0f3460 !important;
+}
+*/
+
+/* Card/shelf backgrounds (e.g., "Quick picks", carousels) */
+/*
+ytmusic-card-shelf-renderer,
+ytmusic-immersive-carousel-renderer {
+  background: #16213e !important;
+}
+*/
+
+/* Filter chips (genre/mood filters) */
+/*
+ytmusic-chip-cloud-chip-renderer {
+  background: #0f3460 !important;
+  color: #e0e0e0 !important;
+}
+*/
+
+/* Active/selected chip */
+/*
+ytmusic-chip-cloud-chip-renderer[chip-style="STYLE_PRIMARY"] {
+  background: #e94560 !important;
+  color: #ffffff !important;
+}
+*/
+
+
+/* ===========================================
+ * MENUS & DIALOGS
+ * ===========================================
+ */
+
+/* Context menus and popup dialogs */
+/*
+tp-yt-paper-dialog,
+tp-yt-paper-listbox {
+  background: #16213e !important;
+  color: #e0e0e0 !important;
+}
+*/
+
+/* Menu items */
+/*
+tp-yt-paper-item {
+  color: #e0e0e0 !important;
+}
+*/
+
+
+/* ===========================================
+ * SCROLLBAR
+ * ===========================================
+ */
+
+/*
+*::-webkit-scrollbar {
+  width: 10px;
+}
+
+*::-webkit-scrollbar-track {
+  background: #1a1a2e !important;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: #0f3460 !important;
+  border-radius: 5px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: #e94560 !important;
+}
+*/
+
+
+/* ===========================================
+ * QUEUE / NOW PLAYING PAGE
+ * ===========================================
+ */
+
+/* Full player page background */
+/*
+ytmusic-player-page,
+#player-page {
+  background: #1a1a2e !important;
+}
+*/
+
+
+/* ===========================================
+ * YOUR CUSTOM STYLES
+ * ===========================================
+ * Add your own custom styles below!
+ */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,9 +27,11 @@ import electronSquirrelStartup from "electron-squirrel-startup";
 import MemoryStore from "./memory-store";
 import playerStateStore, { PlayerState, VideoState } from "./player-state-store";
 import { MemoryStoreSchema, StoreSchema, TrayIconStyle } from "../shared/store/schema";
+import { getPresetThemeById } from "../shared/preset-themes";
 
 import CompanionServer from "./integrations/companion-server";
 import CustomCSS from "./integrations/custom-css";
+import PresetThemes from "./integrations/preset-themes";
 import DiscordPresence from "./integrations/discord-presence";
 import LastFM from "./integrations/last-fm";
 import NowPlayingNotifications from "./integrations/notifications";
@@ -163,6 +165,7 @@ Menu.setApplicationMenu(builtMenu);
 
 const companionServer = new CompanionServer();
 const customCss = new CustomCSS();
+const presetThemes = new PresetThemes();
 const discordPresence = new DiscordPresence();
 const lastFMScrobbler = new LastFM();
 const nowPlayingNotifications = new NowPlayingNotifications();
@@ -351,6 +354,7 @@ const store = new Conf<StoreSchema>({
     },
     appearance: {
       alwaysShowVolumeSlider: false,
+      presetTheme: null,
       customCSSEnabled: false,
       customCSSPath: null,
       zoom: 100,
@@ -422,6 +426,11 @@ const store = new Conf<StoreSchema>({
       if (!store.has("appearance.trayIconStyle")) {
         store.set("appearance.trayIconStyle", 0);
       }
+    },
+    ">=2.0.12": store => {
+      if (!store.has("appearance.presetTheme")) {
+        store.set("appearance.presetTheme", null);
+      }
     }
   }
 });
@@ -457,7 +466,22 @@ store.onDidAnyChange(async (newState, oldState) => {
     }
   }
 
-  // Appearance
+  // Appearance - Preset Themes
+  if (newState.appearance.presetTheme !== null) {
+    presetThemes.provide(store, ytmView);
+  }
+  if (newState.appearance.presetTheme !== null && oldState.appearance.presetTheme === null) {
+    presetThemes.enable();
+    log.info("Integration enabled: Preset Themes");
+  } else if (newState.appearance.presetTheme === null && oldState.appearance.presetTheme !== null) {
+    presetThemes.disable();
+    log.info("Integration disabled: Preset Themes");
+  }
+  if (newState.appearance.presetTheme !== oldState.appearance.presetTheme) {
+    updateTitleBarOverlay(newState.appearance.presetTheme);
+  }
+
+  // Appearance - Custom CSS
   if (newState.appearance.customCSSEnabled) {
     customCss.provide(store, ytmView);
   }
@@ -695,6 +719,33 @@ function getTrayIconPath() {
 
 function setTrayIcon() {
   tray.setImage(getTrayIconPath());
+}
+
+function updateTitleBarOverlay(themeId: string | null) {
+  const theme = themeId ? getPresetThemeById(themeId) : null;
+  const bgColor = theme ? theme.palette.background : "#000000";
+  const textColor = theme ? theme.palette.textSecondary : "#BBBBBB";
+
+  if (mainWindow) {
+    mainWindow.setBackgroundColor(bgColor);
+    if (!isDarwin) {
+      try {
+        mainWindow.setTitleBarOverlay({ color: bgColor, symbolColor: textColor, height: 36 });
+      } catch {
+        /* not supported */
+      }
+    }
+  }
+  if (settingsWindow) {
+    settingsWindow.setBackgroundColor(bgColor);
+    if (!isDarwin) {
+      try {
+        settingsWindow.setTitleBarOverlay({ color: bgColor, symbolColor: textColor, height: 36 });
+      } catch {
+        /* not supported */
+      }
+    }
+  }
 }
 
 // Shortcut registration
@@ -1031,6 +1082,7 @@ const createYTMView = (): void => {
     }
   });
   companionServer.provide(store, memoryStore, ytmView);
+  presetThemes.provide(store, ytmView);
   customCss.provide(store, ytmView);
   ratioVolume.provide(ytmView);
 
@@ -1590,7 +1642,8 @@ app.on("ready", async () => {
 
       // TODO: this is just a hack fix for ratio volume to run the enable script
       ratioVolume.ytmViewLoaded();
-      // TODO: this is just a hack fix for custom css to update CSS when the view loads
+      // TODO: this is just a hack fix for preset themes/custom css to update CSS when the view loads
+      presetThemes.updateTheme();
       customCss.updateCSS();
     }
   });
@@ -1744,6 +1797,22 @@ app.on("ready", async () => {
     if (event.sender !== settingsWindow.webContents) return;
 
     return app.getVersion();
+  });
+
+  ipcMain.handle("app:saveCustomCSSTemplate", async event => {
+    if (event.sender !== settingsWindow.webContents) return null;
+
+    const templatePath = path.join(assetFolder, "custom-css-template.css");
+    const result = await dialog.showSaveDialog(settingsWindow, {
+      title: "Save CSS Template",
+      defaultPath: "custom-css-template.css",
+      filters: [{ name: "CSS Files", extensions: ["css"] }]
+    });
+
+    if (result.canceled || !result.filePath) return null;
+
+    await fs.copyFile(templatePath, result.filePath);
+    return result.filePath;
   });
 
   ipcMain.on("app:checkForUpdates", event => {
@@ -1916,6 +1985,14 @@ app.on("ready", async () => {
   if (store.get("general").showNotificationOnSongChange) {
     nowPlayingNotifications.enable();
     log.info("Integration enabled: Now playing notifications");
+  }
+
+  // PresetThemes (inject before custom CSS so custom CSS can override)
+  if (store.get("appearance").presetTheme !== null) {
+    presetThemes.provide(store, ytmView);
+    presetThemes.enable();
+    updateTitleBarOverlay(store.get("appearance").presetTheme);
+    log.info("Integration enabled: Preset Themes");
   }
 
   // CustomCSS

--- a/src/main/integrations/preset-themes/index.ts
+++ b/src/main/integrations/preset-themes/index.ts
@@ -1,0 +1,110 @@
+import { BrowserView } from "electron";
+import Conf from "conf";
+
+import IIntegration from "../integration";
+import { StoreSchema } from "../../../shared/store/schema";
+import { getPresetThemeById } from "../../../shared/preset-themes";
+import { Unsubscribe } from "conf/dist/source/types";
+
+export default class PresetThemes implements IIntegration {
+  private ytmView: BrowserView;
+  private store: Conf<StoreSchema>;
+  private isEnabled = false;
+  private hasInjectedOnce = false;
+
+  private cssKeys: string[] = [];
+  private storeListener: Unsubscribe | null = null;
+
+  public provide(store: Conf<StoreSchema>, ytmView: BrowserView): void {
+    let ytmViewChanged = false;
+    if (ytmView !== this.ytmView) {
+      ytmViewChanged = true;
+    }
+
+    this.ytmView = ytmView;
+    this.store = store;
+
+    if (ytmViewChanged) {
+      this.cssKeys = [];
+    }
+
+    if ((this.isEnabled && !this.hasInjectedOnce) || (this.isEnabled && ytmViewChanged)) {
+      this.enable();
+    }
+  }
+
+  public enable(): void {
+    this.isEnabled = true;
+    if (this.ytmView === null || this.cssKeys.length > 0) return;
+
+    this.injectTheme();
+
+    if (this.storeListener) {
+      this.storeListener();
+      this.storeListener = null;
+    }
+    this.storeListener = this.store.onDidChange("appearance", (oldState, newState) => {
+      if (newState.presetTheme && oldState.presetTheme !== newState.presetTheme) {
+        this.updateTheme();
+      }
+    });
+  }
+
+  public disable(): void {
+    this.removeTheme();
+    this.isEnabled = false;
+    this.hasInjectedOnce = false;
+
+    if (this.storeListener) {
+      this.storeListener();
+      this.storeListener = null;
+    }
+  }
+
+  public getYTMScripts(): { name: string; script: string }[] {
+    return [];
+  }
+
+  public updateTheme(): void {
+    if (this.isEnabled) {
+      this.removeTheme();
+      this.injectTheme();
+    }
+  }
+
+  private injectTheme() {
+    if (!this.ytmView) return;
+    this.hasInjectedOnce = true;
+
+    const themeId: string | null = this.store.get("appearance.presetTheme");
+    if (!themeId) return;
+
+    const theme = getPresetThemeById(themeId);
+    if (!theme) return;
+
+    this.ytmView.webContents.insertCSS(theme.css).then(ref => {
+      this.cssKeys.push(ref);
+      this.refitYTMPopups();
+    });
+  }
+
+  private removeTheme() {
+    if (this.cssKeys.length === 0 || !this.ytmView) return;
+
+    const keys = [...this.cssKeys];
+    this.cssKeys = [];
+
+    for (const key of keys) {
+      this.ytmView.webContents.removeInsertedCSS(key).catch(() => {
+        // key may be invalid after page reload
+      });
+    }
+    this.refitYTMPopups();
+  }
+
+  private refitYTMPopups() {
+    if (this.ytmView) {
+      this.ytmView.webContents.send("ytmView:refitPopups");
+    }
+  }
+}

--- a/src/renderer/@types/global.d.ts
+++ b/src/renderer/@types/global.d.ts
@@ -20,6 +20,7 @@ declare global {
       restartApplication(): void;
       restartApplicationForUpdate(): void;
       getTrueFilePath(file: File): string;
+      saveCustomCSSTemplate(): Promise<string | null>;
 
       // Companion Authorization specific
       sendResult(authorized: boolean);

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import KeybindInput from "../../components/KeybindInput.vue";
 import YTMDSetting from "../../components/YTMDSetting.vue";
 import { StoreSchema, TrayIconStyle } from "~shared/store/schema";
+import { PRESET_THEMES } from "~shared/preset-themes";
 import { AuthToken } from "~shared/integrations/companion-server/types";
 import logo from "~assets/icons/ytmd.png";
 
@@ -43,6 +44,7 @@ const startOnBoot = ref<boolean>(general.startOnBoot);
 const startMinimized = ref<boolean>(general.startMinimized);
 
 const alwaysShowVolumeSlider = ref<boolean>(appearance.alwaysShowVolumeSlider);
+const presetTheme = ref<string | null>(appearance.presetTheme);
 const customCSSEnabled = ref<boolean>(appearance.customCSSEnabled);
 const customCSSPath = ref<string>(appearance.customCSSPath);
 const zoom = ref<number>(appearance.zoom);
@@ -81,6 +83,7 @@ store.onDidAnyChange(async newState => {
   startMinimized.value = newState.general.startMinimized;
 
   alwaysShowVolumeSlider.value = newState.appearance.alwaysShowVolumeSlider;
+  presetTheme.value = newState.appearance.presetTheme;
   customCSSEnabled.value = newState.appearance.customCSSEnabled;
   customCSSPath.value = newState.appearance.customCSSPath;
   zoom.value = newState.appearance.zoom;
@@ -155,6 +158,7 @@ async function settingsChanged() {
   store.set("general.disableHardwareAcceleration", disableHardwareAcceleration.value);
 
   store.set("appearance.alwaysShowVolumeSlider", alwaysShowVolumeSlider.value);
+  store.set("appearance.presetTheme", presetTheme.value);
   store.set("appearance.customCSSEnabled", customCSSEnabled.value);
   store.set("appearance.zoom", zoom.value);
   store.set("appearance.trayIconStyle", trayIconStyle.value);
@@ -213,6 +217,18 @@ async function deleteCompanionAuthToken(appId: string) {
 
   if (safeStorageAvailable.value)
     store.set("integrations.companionServerAuthTokens", await safeStorage.encryptString(JSON.stringify(companionServerAuthTokens.value)));
+}
+
+function selectTheme(themeId: string | null) {
+  presetTheme.value = themeId;
+  store.set("appearance.presetTheme", themeId);
+}
+
+async function saveCustomCSSTemplate() {
+  const savedPath = await window.ytmd.saveCustomCSSTemplate();
+  if (savedPath && !customCSSPath.value) {
+    store.set("appearance.customCSSPath", savedPath);
+  }
 }
 
 function removeCustomCSSPath() {
@@ -302,8 +318,39 @@ window.ytmd.handleUpdateDownloaded(() => {
         </div>
 
         <div v-if="currentTab === 2" class="appearance-tab">
+          <div class="theme-selector">
+            <p class="section-label">Theme</p>
+            <div class="theme-grid">
+              <div :class="['theme-card', { selected: !presetTheme }]" @click="selectTheme(null)">
+                <div class="theme-preview default-preview">
+                  <span class="material-symbols-outlined">format_paint</span>
+                </div>
+                <p class="theme-name">Default</p>
+              </div>
+              <div
+                v-for="theme in PRESET_THEMES"
+                :key="theme.id"
+                :class="['theme-card', { selected: presetTheme === theme.id }]"
+                @click="selectTheme(theme.id)"
+              >
+                <div class="theme-preview">
+                  <div class="swatch" :style="{ background: theme.palette.background }"></div>
+                  <div class="swatch" :style="{ background: theme.palette.backgroundSecondary }"></div>
+                  <div class="swatch" :style="{ background: theme.palette.accent }"></div>
+                  <div class="swatch" :style="{ background: theme.palette.text }"></div>
+                </div>
+                <p class="theme-name">{{ theme.name }}</p>
+              </div>
+            </div>
+          </div>
           <YTMDSetting v-model="alwaysShowVolumeSlider" type="checkbox" name="Always show volume slider" @change="settingsChanged" />
-          <YTMDSetting v-model="customCSSEnabled" type="checkbox" name="Custom CSS" @change="settingsChanged" />
+          <YTMDSetting
+            v-model="customCSSEnabled"
+            type="checkbox"
+            name="Custom CSS"
+            description="Layer custom CSS on top of the selected theme"
+            @change="settingsChanged"
+          />
           <YTMDSetting
             v-if="customCSSEnabled"
             v-model="customCSSPath"
@@ -314,6 +361,10 @@ window.ytmd.handleUpdateDownloaded(() => {
             @file-change="settingChangedFile"
             @clear="removeCustomCSSPath"
           />
+          <div v-if="customCSSEnabled" class="css-template-hint indented">
+            <p class="hint-text">Not sure where to start? Save a template with documented selectors you can customize.</p>
+            <button class="template-button" @click="saveCustomCSSTemplate"><span class="material-symbols-outlined">download</span>Save CSS template</button>
+          </div>
           <YTMDSetting v-model="zoom" type="range" max="300" min="30" step="10" name="Zoom" @change="settingsChanged" />
           <YTMDSetting
             v-if="isLinux"
@@ -855,6 +906,107 @@ button {
   background-color: #212121;
   cursor: pointer;
   border: none;
+}
+
+.css-template-hint {
+  margin-left: 12px;
+  padding-left: 12px;
+  border-left: 1px solid #212121;
+  margin-bottom: 8px;
+}
+
+.css-template-hint .hint-text {
+  color: #969696;
+  font-size: 13px;
+  margin: 4px 0 8px;
+}
+
+.css-template-hint .template-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 13px;
+  color: #eeeeee;
+}
+
+.css-template-hint .template-button:hover {
+  background-color: #333;
+}
+
+.css-template-hint .template-button .material-symbols-outlined {
+  font-size: 18px;
+}
+
+.theme-selector {
+  margin-bottom: 16px;
+}
+
+.section-label {
+  margin: 8px 0;
+  color: #bbbbbb;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 8px;
+}
+
+.theme-card {
+  cursor: pointer;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 6px;
+  background: #1a1a1a;
+  transition: border-color 0.15s ease;
+}
+
+.theme-card:hover {
+  border-color: #555;
+}
+
+.theme-card.selected {
+  border-color: #f44336;
+}
+
+.theme-preview {
+  border-radius: 4px;
+  overflow: hidden;
+  height: 40px;
+  display: flex;
+}
+
+.theme-preview .swatch {
+  flex: 1;
+}
+
+.default-preview {
+  background: #212121;
+  align-items: center;
+  justify-content: center;
+}
+
+.default-preview .material-symbols-outlined {
+  color: #666;
+  font-size: 22px;
+}
+
+.theme-name {
+  text-align: center;
+  margin: 5px 0 0;
+  font-size: 11px;
+  color: #eeeeee;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .shortcuts-tab .shortcut-title {

--- a/src/renderer/windows/settings/preload.ts
+++ b/src/renderer/windows/settings/preload.ts
@@ -45,5 +45,6 @@ contextBridge.exposeInMainWorld("ytmd", {
   handleUpdateDownloaded: (callback: (event: Electron.IpcRendererEvent) => void) => ipcRenderer.on("app:updateDownloaded", callback),
   isAppUpdateAvailable: async (): Promise<boolean> => await ipcRenderer.invoke("app:isUpdateAvailable"),
   isAppUpdateDownloaded: async (): Promise<boolean> => await ipcRenderer.invoke("app:isUpdateDownloaded"),
-  getTrueFilePath: (file: File) => webUtils.getPathForFile(file)
+  getTrueFilePath: (file: File) => webUtils.getPathForFile(file),
+  saveCustomCSSTemplate: async (): Promise<string | null> => await ipcRenderer.invoke("app:saveCustomCSSTemplate")
 });

--- a/src/shared/preset-themes.ts
+++ b/src/shared/preset-themes.ts
@@ -1,0 +1,221 @@
+export interface ThemePalette {
+  background: string;
+  backgroundSecondary: string;
+  backgroundTertiary: string;
+  accent: string;
+  text: string;
+  textSecondary: string;
+  playerBar: string;
+  hover: string;
+}
+
+export interface PresetTheme {
+  id: string;
+  name: string;
+  description: string;
+  palette: ThemePalette;
+  css: string;
+}
+
+function generateThemeCSS(p: ThemePalette, extraCSS = ""): string {
+  return `
+ytmusic-app {
+  --ytmusic-general-background-a: ${p.background} !important;
+  --ytmusic-general-background-b: ${p.backgroundSecondary} !important;
+  --ytmusic-general-background-c: ${p.backgroundTertiary} !important;
+  --ytmusic-brand-background-solid: ${p.background} !important;
+  --ytmusic-text-primary: ${p.text} !important;
+  --ytmusic-text-secondary: ${p.textSecondary} !important;
+  --ytmusic-color-white1: ${p.text} !important;
+  --ytmusic-color-white2: ${p.textSecondary} !important;
+  --ytmusic-color-white3: ${p.textSecondary} !important;
+  --ytmusic-color-white4: ${p.textSecondary} !important;
+  --ytmusic-selected-indicator-color: ${p.accent} !important;
+}
+
+html,
+body {
+  background-color: ${p.background} !important;
+  color: ${p.text} !important;
+}
+
+ytmusic-app,
+ytmusic-app-layout,
+#layout,
+#main-panel,
+ytmusic-browse-response,
+ytmusic-search-page,
+ytmusic-tabbed-search-results-renderer,
+ytmusic-section-list-renderer,
+#contents.ytmusic-section-list-renderer,
+ytmusic-player-page,
+#player-page,
+ytmusic-two-column-browse-results-renderer,
+ytmusic-two-column-browse-results-renderer #primary,
+ytmusic-two-column-browse-results-renderer #secondary {
+  background-color: ${p.background} !important;
+}
+
+ytmusic-player-bar,
+#player-bar-background {
+  background-color: ${p.playerBar} !important;
+}
+
+#nav-bar-background,
+ytmusic-app-layout > #nav-bar-background,
+div#nav-bar-background,
+ytmusic-nav-bar,
+ytmusic-nav-bar .center-content,
+ytmusic-pivot-bar-renderer {
+  background-color: ${p.background} !important;
+}
+
+ytmusic-app-layout > [slot=nav-bar] {
+  width: 100vw !important;
+}
+
+ytmusic-tabs,
+ytmusic-tabs #tabs.tab-container {
+  background-color: ${p.background} !important;
+}
+
+ytmusic-tabs .tab {
+  color: ${p.textSecondary} !important;
+}
+
+ytmusic-tabs .tab.selected,
+ytmusic-tabs .tab[selected] {
+  color: ${p.text} !important;
+}
+
+tp-yt-app-drawer,
+tp-yt-app-drawer#guide-wrapper,
+#guide-wrapper,
+ytmusic-guide-renderer,
+#guide-content {
+  background-color: ${p.backgroundSecondary} !important;
+}
+
+ytmusic-header-renderer,
+#header-bar {
+  background-color: ${p.background} !important;
+}
+
+ytmusic-search-box[is-bauhaus-sidenav-enabled] .search-container {
+  background-color: ${p.backgroundSecondary} !important;
+  border-color: ${p.backgroundTertiary} !important;
+}
+
+ytmusic-search-box input.style-scope {
+  color: ${p.text} !important;
+}
+
+ytmusic-card-shelf-renderer,
+ytmusic-immersive-carousel-renderer {
+  background-color: ${p.backgroundSecondary} !important;
+}
+
+tp-yt-paper-dialog,
+tp-yt-paper-listbox {
+  background-color: ${p.backgroundSecondary} !important;
+  color: ${p.text} !important;
+}
+
+ytmusic-responsive-list-item-renderer:hover {
+  background-color: ${p.hover} !important;
+}
+
+*::-webkit-scrollbar {
+  background-color: ${p.background} !important;
+}
+
+*::-webkit-scrollbar-track {
+  background-color: ${p.background} !important;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: ${p.backgroundTertiary} !important;
+}
+${extraCSS}`.trim();
+}
+
+function defineTheme(id: string, name: string, description: string, palette: ThemePalette, extraCSS = ""): PresetTheme {
+  return { id, name, description, palette, css: generateThemeCSS(palette, extraCSS) };
+}
+
+export const PRESET_THEMES: PresetTheme[] = [
+  defineTheme("amoled-dark", "AMOLED Dark", "Pure black for OLED screens", {
+    background: "#000000",
+    backgroundSecondary: "#0a0a0a",
+    backgroundTertiary: "#141414",
+    accent: "#ff0000",
+    text: "#ffffff",
+    textSecondary: "#aaaaaa",
+    playerBar: "#000000",
+    hover: "#1a1a1a"
+  }),
+  defineTheme("dark", "Dark", "Warm, refined dark theme", {
+    background: "#181818",
+    backgroundSecondary: "#222222",
+    backgroundTertiary: "#333333",
+    accent: "#ff4444",
+    text: "#e8e8e8",
+    textSecondary: "#999999",
+    playerBar: "#181818",
+    hover: "#2a2a2a"
+  }),
+  defineTheme("catppuccin-mocha", "Catppuccin Mocha", "Warm dark with pastel accents", {
+    background: "#1e1e2e",
+    backgroundSecondary: "#313244",
+    backgroundTertiary: "#45475a",
+    accent: "#cba6f7",
+    text: "#cdd6f4",
+    textSecondary: "#a6adc8",
+    playerBar: "#181825",
+    hover: "#313244"
+  }),
+  defineTheme("dracula", "Dracula", "Classic purple-accented dark theme", {
+    background: "#282a36",
+    backgroundSecondary: "#44475a",
+    backgroundTertiary: "#6272a4",
+    accent: "#bd93f9",
+    text: "#f8f8f2",
+    textSecondary: "#bfbfbf",
+    playerBar: "#21222c",
+    hover: "#44475a"
+  }),
+  defineTheme("nord", "Nord", "Cool arctic blue palette", {
+    background: "#2e3440",
+    backgroundSecondary: "#3b4252",
+    backgroundTertiary: "#434c5e",
+    accent: "#88c0d0",
+    text: "#eceff4",
+    textSecondary: "#d8dee9",
+    playerBar: "#2e3440",
+    hover: "#3b4252"
+  }),
+  defineTheme("gruvbox-dark", "Gruvbox Dark", "Retro warm dark theme", {
+    background: "#282828",
+    backgroundSecondary: "#3c3836",
+    backgroundTertiary: "#504945",
+    accent: "#fe8019",
+    text: "#ebdbb2",
+    textSecondary: "#a89984",
+    playerBar: "#1d2021",
+    hover: "#3c3836"
+  }),
+  defineTheme("rose-pine", "Rose Pine", "Muted dark with rose accents", {
+    background: "#191724",
+    backgroundSecondary: "#1f1d2e",
+    backgroundTertiary: "#26233a",
+    accent: "#ebbcba",
+    text: "#e0def4",
+    textSecondary: "#908caa",
+    playerBar: "#191724",
+    hover: "#26233a"
+  })
+];
+
+export function getPresetThemeById(id: string): PresetTheme | undefined {
+  return PRESET_THEMES.find(t => t.id === id);
+}

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -17,6 +17,7 @@ export type StoreSchema = {
   };
   appearance: {
     alwaysShowVolumeSlider: boolean;
+    presetTheme: string | null;
     customCSSEnabled: boolean;
     customCSSPath: string | null;
     zoom: number;


### PR DESCRIPTION
## Summary
- Adds a theme selector grid in Settings > Appearance with 7 built-in dark themes: AMOLED Dark, Dark, Catppuccin Mocha, Dracula, Nord, Gruvbox Dark, and Rose Pine
- New `PresetThemes` integration service that injects theme CSS into the YouTube Music view, following the existing `IIntegration` pattern
- Dynamic title bar color matching (macOS via `setBackgroundColor`, Windows via `setTitleBarOverlay`)
- Custom CSS template download button with documented YTM selectors for users who want to create their own themes
- Preset themes and custom CSS can be used together (custom CSS layers on top)

## Known Limitations
- **Playlist detail view**: The side panels of the two-column playlist layout (`ytmusic-app-layout #content`) cannot be themed without breaking album art rendering, since setting `background-color` on that element covers the thumbnail images due to YTM's internal stacking context. The playlist content area itself is themed correctly.
- **Fragile by nature**: These themes target YouTube Music's internal CSS selectors and custom properties. YTM updates may break theme coverage at any time, which is an inherent limitation of CSS injection into a third-party web app.

Closes #419

## Test plan
- [ ] Select each theme and verify colors apply across Home, Library, Explore, Search, and playlist pages
- [ ] Switch between themes rapidly and verify clean swaps (no residual CSS)
- [ ] Switch to Default and verify full revert to stock YTM appearance
- [ ] Verify album art thumbnails render correctly with all themes
- [ ] Verify title bar color changes on macOS and Windows
- [ ] Enable Custom CSS on top of a preset theme and verify layering
- [ ] Click "Save CSS template" button and verify the template file saves correctly
- [ ] Restart the app with a theme selected and verify it persists
- [ ] Verify no regressions when no theme is selected (Default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)