### PR TITLE
Add Share button with Telegram sharing to player bar

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -909,7 +909,7 @@ function openExternalFromYtmView(urlString: string) {
   const domainSplit = url.hostname.split(".");
   domainSplit.reverse();
   const domain = `${domainSplit[1]}.${domainSplit[0]}`;
-  if (domain === "google.com" || domain === "youtube.com") {
+  if (domain === "google.com" || domain === "youtube.com" || domain === "t.me" || domain === "telegram.org") {
     shell.openExternal(urlString);
   }
 }

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -14,6 +14,7 @@ import { StoreSchema } from "~shared/store/schema";
 
 import playerBarControlsScript from "./scripts/playerbarcontrols.script?raw";
 import hookPlayerApiEventsScript from "./scripts/hookplayerapievents.script?raw";
+import injectSharePanelScript from "./scripts/injectsharepanel.script?raw";
 import getPlaylistsScript from "./scripts/getplaylists.script?raw";
 import toggleLikeScript from "./scripts/togglelike.script?raw";
 import toggleDislikeScript from "./scripts/toggledislike.script?raw";
@@ -81,11 +82,6 @@ function createStyleSheet() {
 
       .ytmd-player-bar-control.sleep-timer-button.active {
         color: #FFFFFF;
-      }
-
-      .ytmd-player-bar-control.share-button {
-        margin-left: 0px;
-        width: 32px;
       }
     `)
   );
@@ -163,6 +159,10 @@ function createKeyboardNavigation() {
 
 async function createAdditionalPlayerBarControls() {
   (await webFrame.executeJavaScript(playerBarControlsScript))();
+}
+
+async function injectSharePanelTargets() {
+  (await webFrame.executeJavaScript(injectSharePanelScript))();
 }
 
 async function hideChromecastButton() {
@@ -279,6 +279,7 @@ window.addEventListener("load", async () => {
   createNavigationMenuArrows();
   createKeyboardNavigation();
   await createAdditionalPlayerBarControls();
+  await injectSharePanelTargets();
   await hideChromecastButton();
   await hookPlayerApiEvents();
   overrideHistoryButtonDisplay();

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -82,6 +82,11 @@ function createStyleSheet() {
       .ytmd-player-bar-control.sleep-timer-button.active {
         color: #FFFFFF;
       }
+
+      .ytmd-player-bar-control.share-button {
+        margin-left: 0px;
+        width: 32px;
+      }
     `)
   );
   document.head.appendChild(css);

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -83,6 +83,37 @@ function createStyleSheet() {
       .ytmd-player-bar-control.sleep-timer-button.active {
         color: #FFFFFF;
       }
+
+      .ytmd-share-target-button {
+        background: transparent;
+        border: none;
+        margin: 0;
+        padding: 5px 1px 2px 1px;
+        cursor: pointer;
+        display: inline-block;
+        color: inherit;
+        font: inherit;
+        text-align: center;
+      }
+
+      .ytmd-share-target-icon {
+        display: block;
+        margin: 0 4px 8px 4px;
+      }
+
+      .ytmd-share-target-icon svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+
+      .ytmd-share-target-label {
+        display: block;
+        font-size: 12px;
+        font-weight: 400;
+        color: #fff;
+        text-align: center;
+      }
     `)
   );
   document.head.appendChild(css);

--- a/src/renderer/ytmview/scripts/injectsharepanel.script.d.ts
+++ b/src/renderer/ytmview/scripts/injectsharepanel.script.d.ts
@@ -1,0 +1,2 @@
+declare const content: string;
+export = content;

--- a/src/renderer/ytmview/scripts/injectsharepanel.script.js
+++ b/src/renderer/ytmview/scripts/injectsharepanel.script.js
@@ -1,0 +1,69 @@
+(function () {
+  const telegramSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" focusable="false" aria-hidden="true" style="pointer-events: none; display: inherit; width: 100%; height: 100%;"><circle cx="30" cy="30" r="30" fill="#229ED9"/><path fill="#fff" d="M44.426 16.95L39.303 41.1c-.386 1.708-1.39 2.126-2.816 1.324l-7.78-5.732-3.755 3.614c-.414.415-.763.764-1.562.764l.556-7.881 14.354-12.97c.625-.555-.136-.866-.965-.31L19.6 29.073l-7.65-2.393c-1.663-.52-1.696-1.663.347-2.463l29.894-11.52c1.386-.513 2.6.312 2.236 2.252z"/></svg>`;
+
+  function createTelegramTarget(template) {
+    const telegramTarget = template.cloneNode(true);
+
+    const btn = telegramTarget.querySelector("button#target");
+    btn.setAttribute("title", "Telegram");
+    btn.setAttribute("aria-label", "Telegram");
+
+    const titleDiv = telegramTarget.querySelector("#title");
+    if (titleDiv) titleDiv.textContent = "Telegram";
+
+    const iconDiv = telegramTarget.querySelector(".yt-icon-shape > div");
+    if (iconDiv) iconDiv.innerHTML = telegramSvg;
+
+    const handleShare = e => {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      const dialog = document.querySelector("ytmusic-unified-share-panel-renderer");
+      const urlInput = dialog ? dialog.querySelector("input#share-url") : null;
+      const shareUrl = urlInput ? urlInput.value : null;
+      if (shareUrl) {
+        window.open(`https://t.me/share/url?url=${encodeURIComponent(shareUrl)}`);
+      }
+    };
+
+    telegramTarget.addEventListener("click", handleShare, { capture: true });
+    btn.addEventListener("click", handleShare, { capture: true });
+
+    return telegramTarget;
+  }
+
+  function injectTelegramIntoPanel(panel) {
+    const toolbar = panel.querySelector('#contents[role="toolbar"]');
+    if (!toolbar) return false;
+    if (toolbar.querySelector('[title="Telegram"]')) return true;
+
+    const existing = toolbar.querySelector("yt-share-target-renderer");
+    if (!existing) return false;
+
+    toolbar.appendChild(createTelegramTarget(existing));
+    return true;
+  }
+
+  function tryInjectWithRetries(panel, attemptsLeft) {
+    if (injectTelegramIntoPanel(panel)) return;
+    if (attemptsLeft <= 0) return;
+    setTimeout(() => tryInjectWithRetries(panel, attemptsLeft - 1), 50);
+  }
+
+  const observer = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        const panel =
+          node.matches && node.matches("ytmusic-unified-share-panel-renderer")
+            ? node
+            : node.querySelector && node.querySelector("ytmusic-unified-share-panel-renderer");
+        if (panel) {
+          tryInjectWithRetries(panel, 20);
+        }
+      }
+    }
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+});

--- a/src/renderer/ytmview/scripts/injectsharepanel.script.js
+++ b/src/renderer/ytmview/scripts/injectsharepanel.script.js
@@ -1,69 +1,140 @@
 (function () {
-  const telegramSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" focusable="false" aria-hidden="true" style="pointer-events: none; display: inherit; width: 100%; height: 100%;"><circle cx="30" cy="30" r="30" fill="#229ED9"/><path fill="#fff" d="M44.426 16.95L39.303 41.1c-.386 1.708-1.39 2.126-2.816 1.324l-7.78-5.732-3.755 3.614c-.414.415-.763.764-1.562.764l.556-7.881 14.354-12.97c.625-.555-.136-.866-.965-.31L19.6 29.073l-7.65-2.393c-1.663-.52-1.696-1.663.347-2.463l29.894-11.52c1.386-.513 2.6.312 2.236 2.252z"/></svg>`;
+  const SVG_NS = "http://www.w3.org/2000/svg";
+  const processedPanels = new WeakSet();
 
-  function createTelegramTarget(template) {
-    const telegramTarget = template.cloneNode(true);
+  function createTelegramSvg() {
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.setAttribute("viewBox", "0 0 60 60");
+    svg.setAttribute("focusable", "false");
+    svg.setAttribute("aria-hidden", "true");
 
-    const btn = telegramTarget.querySelector("button#target");
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("cx", "30");
+    circle.setAttribute("cy", "30");
+    circle.setAttribute("r", "30");
+    circle.setAttribute("fill", "#229ED9");
+
+    const path = document.createElementNS(SVG_NS, "path");
+    path.setAttribute("fill", "#fff");
+    path.setAttribute(
+      "d",
+      "M44.426 16.95L39.303 41.1c-.386 1.708-1.39 2.126-2.816 1.324l-7.78-5.732-3.755 3.614c-.414.415-.763.764-1.562.764l.556-7.881 14.354-12.97c.625-.555-.136-.866-.965-.31L19.6 29.073l-7.65-2.393c-1.663-.52-1.696-1.663.347-2.463l29.894-11.52c1.386-.513 2.6.312 2.236 2.252z"
+    );
+
+    svg.appendChild(circle);
+    svg.appendChild(path);
+    return svg;
+  }
+
+  function buildTelegramInner(iconSize) {
+    const btn = document.createElement("button");
+    btn.className = "ytmd-share-target-button";
     btn.setAttribute("title", "Telegram");
     btn.setAttribute("aria-label", "Telegram");
 
-    const titleDiv = telegramTarget.querySelector("#title");
-    if (titleDiv) titleDiv.textContent = "Telegram";
+    const iconSpan = document.createElement("span");
+    iconSpan.className = "ytmd-share-target-icon";
+    iconSpan.style.width = iconSize.width + "px";
+    iconSpan.style.height = iconSize.height + "px";
+    iconSpan.appendChild(createTelegramSvg());
 
-    const iconDiv = telegramTarget.querySelector(".yt-icon-shape > div");
-    if (iconDiv) iconDiv.innerHTML = telegramSvg;
+    const labelDiv = document.createElement("div");
+    labelDiv.className = "ytmd-share-target-label";
+    labelDiv.textContent = "Telegram";
 
-    const handleShare = e => {
-      e.preventDefault();
-      e.stopImmediatePropagation();
-
-      const dialog = document.querySelector("ytmusic-unified-share-panel-renderer");
-      const urlInput = dialog ? dialog.querySelector("input#share-url") : null;
-      const shareUrl = urlInput ? urlInput.value : null;
-      if (shareUrl) {
-        window.open(`https://t.me/share/url?url=${encodeURIComponent(shareUrl)}`);
-      }
-    };
-
-    telegramTarget.addEventListener("click", handleShare, { capture: true });
-    btn.addEventListener("click", handleShare, { capture: true });
-
-    return telegramTarget;
+    btn.appendChild(iconSpan);
+    btn.appendChild(labelDiv);
+    return btn;
   }
 
-  function injectTelegramIntoPanel(panel) {
+  function injectTelegram(panel, toolbar, template) {
+    const clone = template.cloneNode(true);
+    toolbar.appendChild(clone);
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const siblingIcon = template.querySelector("yt-icon, .yt-icon-shape");
+        const iconSize = siblingIcon
+          ? siblingIcon.getBoundingClientRect()
+          : { width: 60, height: 60 };
+
+        while (clone.firstChild) clone.removeChild(clone.firstChild);
+
+        const inner = buildTelegramInner(iconSize);
+        clone.appendChild(inner);
+
+        const handleShare = e => {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          const dialog = document.querySelector("ytmusic-unified-share-panel-renderer");
+          const urlInput = dialog ? dialog.querySelector("input#share-url") : null;
+          const shareUrl = urlInput ? urlInput.value : null;
+          if (shareUrl) {
+            window.open(`https://t.me/share/url?url=${encodeURIComponent(shareUrl)}`);
+          }
+        };
+
+        clone.addEventListener("click", handleShare, { capture: true });
+        inner.addEventListener("click", handleShare, { capture: true });
+      });
+    });
+  }
+
+  function tryInject(panel) {
+    if (processedPanels.has(panel)) return true;
+
     const toolbar = panel.querySelector('#contents[role="toolbar"]');
     if (!toolbar) return false;
-    if (toolbar.querySelector('[title="Telegram"]')) return true;
 
-    const existing = toolbar.querySelector("yt-share-target-renderer");
-    if (!existing) return false;
+    const template = toolbar.querySelector("yt-share-target-renderer");
+    if (!template) return false;
 
-    toolbar.appendChild(createTelegramTarget(existing));
+    processedPanels.add(panel);
+    injectTelegram(panel, toolbar, template);
     return true;
   }
 
-  function tryInjectWithRetries(panel, attemptsLeft) {
-    if (injectTelegramIntoPanel(panel)) return;
-    if (attemptsLeft <= 0) return;
-    setTimeout(() => tryInjectWithRetries(panel, attemptsLeft - 1), 50);
+  function waitForPanelReady(panel) {
+    if (tryInject(panel)) return;
+
+    const innerObserver = new MutationObserver(() => {
+      if (tryInject(panel)) {
+        innerObserver.disconnect();
+      }
+    });
+    innerObserver.observe(panel, { childList: true, subtree: true });
+
+    setTimeout(() => innerObserver.disconnect(), 5000);
+  }
+
+  function checkExistingPanel() {
+    const panel = document.querySelector("ytmusic-unified-share-panel-renderer");
+    if (panel && !processedPanels.has(panel)) {
+      waitForPanelReady(panel);
+    }
   }
 
   const observer = new MutationObserver(mutations => {
     for (const mutation of mutations) {
       for (const node of mutation.addedNodes) {
         if (node.nodeType !== 1) continue;
-        const panel =
-          node.matches && node.matches("ytmusic-unified-share-panel-renderer")
-            ? node
-            : node.querySelector && node.querySelector("ytmusic-unified-share-panel-renderer");
-        if (panel) {
-          tryInjectWithRetries(panel, 20);
+
+        let panel = null;
+        if (node.matches && node.matches("ytmusic-unified-share-panel-renderer")) {
+          panel = node;
+        } else if (node.querySelector) {
+          panel = node.querySelector("ytmusic-unified-share-panel-renderer");
+        }
+
+        if (panel && !processedPanels.has(panel)) {
+          waitForPanelReady(panel);
         }
       }
     }
   });
 
   observer.observe(document.body, { childList: true, subtree: true });
-});
+
+  checkExistingPanel();
+  setInterval(checkExistingPanel, 1000);
+})

--- a/src/renderer/ytmview/scripts/playerbarcontrols.script.js
+++ b/src/renderer/ytmview/scripts/playerbarcontrols.script.js
@@ -340,86 +340,6 @@
   };
   rightControls.querySelector(".shuffle").insertAdjacentElement("afterend", sleepTimerButton);
 
-  let shareButton = document.createElement("yt-icon-button");
-  let shareMenuOpen = false;
-  let shareIcon = document.createElement("yt-icon");
-  shareIcon.set("icon", "SHARE");
-  shareButton.appendChild(shareIcon);
-
-  shareButton.setAttribute("title", "Share");
-  shareButton.classList.add("ytmusic-player-bar");
-  shareButton.classList.add("ytmd-player-bar-control");
-  shareButton.classList.add("share-button");
-  shareButton.onclick = () => {
-    if (shareMenuOpen) {
-      shareButton.dispatchEvent(
-        new CustomEvent("yt-action", {
-          bubbles: true,
-          cancelable: false,
-          composed: true,
-          detail: {
-            actionName: "yt-close-popups-action",
-            args: [["ytmusic-menu-popup-renderer"]],
-            optionalAction: false,
-            returnValue: []
-          }
-        })
-      );
-      return;
-    }
-
-    shareButton.dispatchEvent(
-      new CustomEvent("yt-action", {
-        bubbles: true,
-        cancelable: false,
-        composed: true,
-        detail: {
-          actionName: "yt-open-popup-action",
-          args: [
-            {
-              openPopupAction: {
-                popup: {
-                  menuPopupRenderer: {
-                    accessibilityData: {
-                      label: "Share menu"
-                    },
-                    items: [
-                      {
-                        menuServiceItemRenderer: {
-                          icon: {
-                            iconType: "SEND"
-                          },
-                          serviceEndpoint: {
-                            ytmdShareServiceEndpoint: {
-                              platform: "telegram"
-                            }
-                          },
-                          text: {
-                            runs: [
-                              {
-                                text: "Telegram"
-                              }
-                            ]
-                          }
-                        }
-                      }
-                    ]
-                  }
-                },
-                popupType: "DROPDOWN"
-              }
-            },
-            shareButton
-          ],
-          optionalAction: false,
-          returnValue: []
-        }
-      })
-    );
-    shareMenuOpen = true;
-  };
-  sleepTimerButton.insertAdjacentElement("afterend", shareButton);
-
   const humanizeTime = time => {
     // This is just a hacked together function to provide a humanization for the sleep timer. It serves no purpose outside that and isn't some complicated humanizer
     if (time === 1) return `${time} minute`;
@@ -429,28 +349,7 @@
   };
 
   window.addEventListener("yt-action", e => {
-    if (e.detail.actionName === "yt-close-popups-action") {
-      shareMenuOpen = false;
-    }
-
     if (e.detail.actionName === "yt-service-request") {
-      if (e.detail.args[1].ytmdShareServiceEndpoint) {
-        try {
-          const platform = e.detail.args[1].ytmdShareServiceEndpoint.platform;
-          const playerBar = document.querySelector("ytmusic-app-layout>ytmusic-player-bar");
-          const videoDetails = playerBar.playerApi.getPlayerResponse()?.videoDetails;
-          if (videoDetails) {
-            const songUrl = `https://music.youtube.com/watch?v=${videoDetails.videoId}`;
-            const text = `${videoDetails.title} - ${videoDetails.author}`;
-            if (platform === "telegram") {
-              window.open(`https://t.me/share/url?url=${encodeURIComponent(songUrl)}&text=${encodeURIComponent(text)}`);
-            }
-          }
-        } catch (e) {
-          // no video playing
-        }
-      }
-
       if (e.detail.args[1].ytmdSleepTimerServiceEndpoint) {
         if (sleepTimerTimeout !== null) {
           clearTimeout(sleepTimerTimeout);

--- a/src/renderer/ytmview/scripts/playerbarcontrols.script.js
+++ b/src/renderer/ytmview/scripts/playerbarcontrols.script.js
@@ -340,6 +340,86 @@
   };
   rightControls.querySelector(".shuffle").insertAdjacentElement("afterend", sleepTimerButton);
 
+  let shareButton = document.createElement("yt-icon-button");
+  let shareMenuOpen = false;
+  let shareIcon = document.createElement("yt-icon");
+  shareIcon.set("icon", "SHARE");
+  shareButton.appendChild(shareIcon);
+
+  shareButton.setAttribute("title", "Share");
+  shareButton.classList.add("ytmusic-player-bar");
+  shareButton.classList.add("ytmd-player-bar-control");
+  shareButton.classList.add("share-button");
+  shareButton.onclick = () => {
+    if (shareMenuOpen) {
+      shareButton.dispatchEvent(
+        new CustomEvent("yt-action", {
+          bubbles: true,
+          cancelable: false,
+          composed: true,
+          detail: {
+            actionName: "yt-close-popups-action",
+            args: [["ytmusic-menu-popup-renderer"]],
+            optionalAction: false,
+            returnValue: []
+          }
+        })
+      );
+      return;
+    }
+
+    shareButton.dispatchEvent(
+      new CustomEvent("yt-action", {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        detail: {
+          actionName: "yt-open-popup-action",
+          args: [
+            {
+              openPopupAction: {
+                popup: {
+                  menuPopupRenderer: {
+                    accessibilityData: {
+                      label: "Share menu"
+                    },
+                    items: [
+                      {
+                        menuServiceItemRenderer: {
+                          icon: {
+                            iconType: "SEND"
+                          },
+                          serviceEndpoint: {
+                            ytmdShareServiceEndpoint: {
+                              platform: "telegram"
+                            }
+                          },
+                          text: {
+                            runs: [
+                              {
+                                text: "Telegram"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                popupType: "DROPDOWN"
+              }
+            },
+            shareButton
+          ],
+          optionalAction: false,
+          returnValue: []
+        }
+      })
+    );
+    shareMenuOpen = true;
+  };
+  sleepTimerButton.insertAdjacentElement("afterend", shareButton);
+
   const humanizeTime = time => {
     // This is just a hacked together function to provide a humanization for the sleep timer. It serves no purpose outside that and isn't some complicated humanizer
     if (time === 1) return `${time} minute`;
@@ -349,7 +429,28 @@
   };
 
   window.addEventListener("yt-action", e => {
+    if (e.detail.actionName === "yt-close-popups-action") {
+      shareMenuOpen = false;
+    }
+
     if (e.detail.actionName === "yt-service-request") {
+      if (e.detail.args[1].ytmdShareServiceEndpoint) {
+        try {
+          const platform = e.detail.args[1].ytmdShareServiceEndpoint.platform;
+          const playerBar = document.querySelector("ytmusic-app-layout>ytmusic-player-bar");
+          const videoDetails = playerBar.playerApi.getPlayerResponse()?.videoDetails;
+          if (videoDetails) {
+            const songUrl = `https://music.youtube.com/watch?v=${videoDetails.videoId}`;
+            const text = `${videoDetails.title} - ${videoDetails.author}`;
+            if (platform === "telegram") {
+              window.open(`https://t.me/share/url?url=${encodeURIComponent(songUrl)}&text=${encodeURIComponent(text)}`);
+            }
+          }
+        } catch (e) {
+          // no video playing
+        }
+      }
+
       if (e.detail.args[1].ytmdSleepTimerServiceEndpoint) {
         if (sleepTimerTimeout !== null) {
           clearTimeout(sleepTimerTimeout);


### PR DESCRIPTION
## Summary
- Adds a Share dropdown button to the player bar right controls (next to sleep timer)
- Telegram is the first share target -- clicking it opens the Telegram share page with the current song URL and title pre-filled
- Uses the existing YTM popup menu system (same pattern as sleep timer) so adding future share platforms is just adding a new menu item + handler case
- Allows `t.me` and `telegram.org` in the external URL allowlist

## Test plan
- [ ] Play a song, verify Share icon appears in the right controls area of the player bar
- [ ] Click Share button, verify dropdown menu appears with "Telegram" item
- [ ] Click Share button again while menu is open, verify it closes
- [ ] Click "Telegram", verify browser opens `t.me/share/url` with correct song URL and title
- [ ] Verify no errors when clicking Share with no song playing


<img width="1707" height="670" alt="Screenshot 2026-03-31 at 12 13 00" src="https://github.com/user-attachments/assets/70caac12-7556-492e-ba00-7463835a1e2a" />


<img width="1237" height="596" alt="Screenshot 2026-03-31 at 12 12 20" src="https://github.com/user-attachments/assets/b87cd3b2-8007-4fd3-a43e-d20aad19b737" />

Narrow Viewports

<img width="707" height="397" alt="Screenshot 2026-03-31 at 12 13 39" src="https://github.com/user-attachments/assets/60bda301-fb9f-4b2e-8e93-d3f1516e74e5" />


Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)