### PR TITLE
feat: restore playback timestamp on continue where you left off

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -383,6 +383,7 @@ const store = new Conf<StoreSchema>({
       lastUrl: "https://music.youtube.com/",
       lastPlaylistId: "",
       lastVideoId: "",
+      lastVideoProgress: 0,
       windowBounds: null,
       windowMaximized: false
     },
@@ -564,6 +565,7 @@ function saveState() {
   store.set("state.lastUrl", lastUrl);
   store.set("state.lastVideoId", lastVideoId);
   store.set("state.lastPlaylistId", lastPlaylistId);
+  store.set("state.lastVideoProgress", playerStateStore.getState().videoProgress);
 }
 
 // Automatic background state saving every 5 minutes

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -330,6 +330,32 @@ window.addEventListener("load", async () => {
         `)
       )();
     }
+
+    // Restore playback position from last session
+    if (state.lastVideoProgress > 0) {
+      const savedProgress = state.lastVideoProgress;
+      (
+        await webFrame.executeJavaScript(`
+          (function() {
+            const playerBar = document.querySelector("ytmusic-app-layout>ytmusic-player-bar");
+
+            // Try seeking immediately in case video is already loaded
+            try {
+              playerBar.playerApi.seekTo(${savedProgress});
+            } catch(e) {}
+
+            // Also listen for state changes as a fallback
+            const onStateChange = (newState) => {
+              if (newState === 1 || newState === 2 || newState === 3 || newState === 5) {
+                playerBar.playerApi.seekTo(${savedProgress});
+                playerBar.playerApi.removeEventListener("onStateChange", onStateChange);
+              }
+            };
+            playerBar.playerApi.addEventListener("onStateChange", onStateChange);
+          })
+        `)
+      )();
+    }
   }
 
   const alwaysShowVolumeSlider = (await store.get("appearance")).alwaysShowVolumeSlider;

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -49,6 +49,7 @@ export type StoreSchema = {
     lastUrl: string;
     lastPlaylistId: string;
     lastVideoId: string;
+    lastVideoProgress: number;
     windowBounds: Electron.Rectangle | null;
     windowMaximized: boolean;
   };


### PR DESCRIPTION
## Summary
- Saves `videoProgress` to the persistent store alongside the existing `lastUrl`, `lastVideoId`, and `lastPlaylistId`
- On restore, seeks to the saved timestamp immediately (and via state change listener as fallback)
- Works for both audio tracks and music videos

Closes #455

## Test plan
- [ ] Enable "Continue where you left off" in Settings > Playback
- [ ] Play a song, let it reach ~1:30
- [ ] Close the app
- [ ] Reopen the app, verify the progress bar shows ~1:30 (not 0:00)
- [ ] Test with "Pause on application launch" both enabled and disabled
- [ ] Test with a music video to verify video tab + timestamp restore