### PR TITLE
Add restart track & pause and next track & pause keyboard shortcuts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -328,6 +328,8 @@ function anyShortcutChanged(newState: Readonly<StoreSchema>, oldState: Readonly<
   if (newState.shortcuts.thumbsUp !== oldState.shortcuts.thumbsUp) return true;
   if (newState.shortcuts.volumeDown !== oldState.shortcuts.volumeDown) return true;
   if (newState.shortcuts.volumeUp !== oldState.shortcuts.volumeUp) return true;
+  if (newState.shortcuts.restartTrack !== oldState.shortcuts.restartTrack) return true;
+  if (newState.shortcuts.nextAndPause !== oldState.shortcuts.nextAndPause) return true;
 
   return false;
 }
@@ -377,7 +379,9 @@ const store = new Conf<StoreSchema>({
       thumbsUp: "",
       thumbsDown: "",
       volumeUp: "",
-      volumeDown: ""
+      volumeDown: "",
+      restartTrack: "",
+      nextAndPause: ""
     },
     state: {
       lastUrl: "https://music.youtube.com/",
@@ -863,6 +867,52 @@ function registerShortcuts() {
     }
   } else {
     memoryStore.set("shortcutsVolumeDownRegisterFailed", false);
+  }
+
+  if (shortcuts.restartTrack) {
+    let registered = false;
+    try {
+      registered = globalShortcut.register(shortcuts.restartTrack, () => {
+        if (ytmView) {
+          ytmView.webContents.send("remoteControl:execute", "restartTrack");
+        }
+      });
+    } catch {
+      /* empty */
+    }
+
+    if (!registered) {
+      log.info("Failed to register shortcut: restartTrack");
+      memoryStore.set("shortcutsRestartTrackRegisterFailed", true);
+    } else {
+      log.info("Registered shortcut: restartTrack");
+      memoryStore.set("shortcutsRestartTrackRegisterFailed", false);
+    }
+  } else {
+    memoryStore.set("shortcutsRestartTrackRegisterFailed", false);
+  }
+
+  if (shortcuts.nextAndPause) {
+    let registered = false;
+    try {
+      registered = globalShortcut.register(shortcuts.nextAndPause, () => {
+        if (ytmView) {
+          ytmView.webContents.send("remoteControl:execute", "nextAndPause");
+        }
+      });
+    } catch {
+      /* empty */
+    }
+
+    if (!registered) {
+      log.info("Failed to register shortcut: nextAndPause");
+      memoryStore.set("shortcutsNextAndPauseRegisterFailed", true);
+    } else {
+      log.info("Registered shortcut: nextAndPause");
+      memoryStore.set("shortcutsNextAndPauseRegisterFailed", false);
+    }
+  } else {
+    memoryStore.set("shortcutsNextAndPauseRegisterFailed", false);
   }
 
   log.info("Registered shortcuts");

--- a/src/main/integrations/companion-server/api-shared/schemas.ts
+++ b/src/main/integrations/companion-server/api-shared/schemas.ts
@@ -67,6 +67,12 @@ export const APIV1CommandRequestBody = Type.Union([
   }),
   Type.Object({
     command: Type.Literal("toggleDislike")
+  }),
+  Type.Object({
+    command: Type.Literal("restartTrack")
+  }),
+  Type.Object({
+    command: Type.Literal("nextAndPause")
   })
 ]);
 export type APIV1CommandRequestBodyType = Static<typeof APIV1CommandRequestBody>;

--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -227,6 +227,16 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
           ytmView.webContents.send("remoteControl:execute", "toggleDislike");
           break;
         }
+
+        case "restartTrack": {
+          ytmView.webContents.send("remoteControl:execute", "restartTrack");
+          break;
+        }
+
+        case "nextAndPause": {
+          ytmView.webContents.send("remoteControl:execute", "nextAndPause");
+          break;
+        }
       }
     }
   };

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -69,6 +69,8 @@ const shortcutThumbsUp = ref<string>(shortcuts.thumbsUp);
 const shortcutThumbsDown = ref<string>(shortcuts.thumbsDown);
 const shortcutVolumeUp = ref<string>(shortcuts.volumeUp);
 const shortcutVolumeDown = ref<string>(shortcuts.volumeDown);
+const shortcutRestartTrack = ref<string>(shortcuts.restartTrack ?? "");
+const shortcutNextAndPause = ref<string>(shortcuts.nextAndPause ?? "");
 
 const lastFMSessionKey = ref<string>(lastFM.sessionKey);
 const scrobblePercent = ref<number>(lastFM.scrobblePercent);
@@ -109,6 +111,8 @@ store.onDidAnyChange(async newState => {
   shortcutThumbsDown.value = newState.shortcuts.thumbsDown;
   shortcutVolumeUp.value = newState.shortcuts.volumeUp;
   shortcutVolumeDown.value = newState.shortcuts.volumeDown;
+  shortcutRestartTrack.value = newState.shortcuts.restartTrack;
+  shortcutNextAndPause.value = newState.shortcuts.nextAndPause;
 });
 
 const discordPresenceConnectionFailed = ref<boolean>(await memoryStore.get("discordPresenceConnectionFailed"));
@@ -120,6 +124,8 @@ const shortcutsThumbsUpRegisterFailed = ref<boolean>(await memoryStore.get("shor
 const shortcutsThumbsDownRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsThumbsDownRegisterFailed"));
 const shortcutsVolumeUpRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsVolumeUpRegisterFailed"));
 const shortcutsVolumeDownRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsVolumeDownRegisterFailed"));
+const shortcutsRestartTrackRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsRestartTrackRegisterFailed"));
+const shortcutsNextAndPauseRegisterFailed = ref<boolean>(await memoryStore.get("shortcutsNextAndPauseRegisterFailed"));
 
 const companionServerAuthWindowEnabled = ref<boolean>(await memoryStore.get("companionServerAuthWindowEnabled"));
 
@@ -135,6 +141,8 @@ memoryStore.onStateChanged(newState => {
   shortcutsThumbsDownRegisterFailed.value = newState.shortcutsThumbsDownRegisterFailed;
   shortcutsVolumeUpRegisterFailed.value = newState.shortcutsVolumeUpRegisterFailed;
   shortcutsVolumeDownRegisterFailed.value = newState.shortcutsVolumeDownRegisterFailed;
+  shortcutsRestartTrackRegisterFailed.value = newState.shortcutsRestartTrackRegisterFailed;
+  shortcutsNextAndPauseRegisterFailed.value = newState.shortcutsNextAndPauseRegisterFailed;
 
   companionServerAuthWindowEnabled.value = newState.companionServerAuthWindowEnabled;
 
@@ -178,6 +186,8 @@ async function settingsChanged() {
   store.set("shortcuts.thumbsDown", shortcutThumbsDown.value);
   store.set("shortcuts.volumeUp", shortcutVolumeUp.value);
   store.set("shortcuts.volumeDown", shortcutVolumeDown.value);
+  store.set("shortcuts.restartTrack", shortcutRestartTrack.value);
+  store.set("shortcuts.nextAndPause", shortcutNextAndPause.value);
 }
 
 async function settingChangedRequiresRestart() {
@@ -516,6 +526,28 @@ window.ytmd.handleUpdateDownloaded(() => {
               >
             </p>
             <KeybindInput v-model="shortcutVolumeDown" @change="settingsChanged" />
+          </div>
+          <div class="setting">
+            <p class="shortcut-title">
+              Restart Track &amp; Pause<span
+                v-if="shortcutsRestartTrackRegisterFailed"
+                class="material-symbols-outlined register-error"
+                title="Failed to register keybind. Does another application have this keybind?"
+                >error</span
+              >
+            </p>
+            <KeybindInput v-model="shortcutRestartTrack" @change="settingsChanged" />
+          </div>
+          <div class="setting">
+            <p class="shortcut-title">
+              Next Track &amp; Pause<span
+                v-if="shortcutsNextAndPauseRegisterFailed"
+                class="material-symbols-outlined register-error"
+                title="Failed to register keybind. Does another application have this keybind?"
+                >error</span
+              >
+            </p>
+            <KeybindInput v-model="shortcutNextAndPause" @change="settingsChanged" />
           </div>
         </div>
 

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -512,6 +512,37 @@ window.addEventListener("load", async () => {
         )(value);
         break;
 
+      case "restartTrack":
+        (
+          await webFrame.executeJavaScript(`
+            (function() {
+              const playerBar = document.querySelector("ytmusic-app-layout>ytmusic-player-bar");
+              playerBar.playerApi.seekTo(0);
+              playerBar.playerApi.pauseVideo();
+            })
+          `)
+        )();
+        break;
+
+      case "nextAndPause":
+        (
+          await webFrame.executeJavaScript(`
+            (function() {
+              const playerBar = document.querySelector("ytmusic-app-layout>ytmusic-player-bar");
+              const handler = (state) => {
+                // State 1 = playing. Pause as soon as the next track starts.
+                if (state === 1) {
+                  playerBar.playerApi.removeEventListener("onStateChange", handler);
+                  playerBar.playerApi.pauseVideo();
+                }
+              };
+              playerBar.playerApi.addEventListener("onStateChange", handler);
+              playerBar.playerApi.nextVideo();
+            })
+          `)
+        )();
+        break;
+
       case "shuffle":
         (
           await webFrame.executeJavaScript(`

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -44,6 +44,8 @@ export type StoreSchema = {
     thumbsDown: string;
     volumeUp: string;
     volumeDown: string;
+    restartTrack: string;
+    nextAndPause: string;
   };
   state: {
     lastUrl: string;
@@ -73,6 +75,8 @@ export type MemoryStoreSchema = {
   shortcutsThumbsDownRegisterFailed: boolean;
   shortcutsVolumeUpRegisterFailed: boolean;
   shortcutsVolumeDownRegisterFailed: boolean;
+  shortcutsRestartTrackRegisterFailed: boolean;
+  shortcutsNextAndPauseRegisterFailed: boolean;
   companionServerAuthWindowEnabled: boolean;
   safeStorageAvailable: boolean;
   autoUpdaterDisabled: boolean;


### PR DESCRIPTION
## Summary
- Adds two new configurable global keyboard shortcuts: "Restart Track & Pause" (seek to 0:00 and pause) and "Next Track & Pause" (skip to next track and pause)
- New entries appear in Settings > Shortcuts, following the existing shortcut pattern
- Also available via the companion server API as `restartTrack` and `nextAndPause` commands


<img width="814" height="611" alt="Screenshot 2026-03-31 at 12 17 09" src="https://github.com/user-attachments/assets/57e8c72d-9625-4ded-983a-864e008fa23e" />


Closes #501

## Test plan
- [ ] Open Settings > Shortcuts, verify "Restart Track & Pause" and "Next Track & Pause" appear
- [ ] Bind shortcuts and test Restart Track & Pause: song should seek to beginning and pause
- [ ] Bind shortcuts and test Next Track & Pause: should skip to next track and pause once it loads
- [ ] Verify error icon appears when binding a conflicting key
- [ ] Verify clearing a shortcut does not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)