### PR TITLE
feat: add centered player controls option

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -351,6 +351,7 @@ const store = new Conf<StoreSchema>({
     },
     appearance: {
       alwaysShowVolumeSlider: false,
+      centeredPlayerControls: false,
       customCSSEnabled: false,
       customCSSPath: null,
       zoom: 100,
@@ -421,6 +422,11 @@ const store = new Conf<StoreSchema>({
     ">=2.0.7": store => {
       if (!store.has("appearance.trayIconStyle")) {
         store.set("appearance.trayIconStyle", 0);
+      }
+    },
+    ">=2.0.11": store => {
+      if (!store.has("appearance.centeredPlayerControls")) {
+        store.set("appearance.centeredPlayerControls", false);
       }
     }
   }

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -43,6 +43,7 @@ const startOnBoot = ref<boolean>(general.startOnBoot);
 const startMinimized = ref<boolean>(general.startMinimized);
 
 const alwaysShowVolumeSlider = ref<boolean>(appearance.alwaysShowVolumeSlider);
+const centeredPlayerControls = ref<boolean>(appearance.centeredPlayerControls);
 const customCSSEnabled = ref<boolean>(appearance.customCSSEnabled);
 const customCSSPath = ref<string>(appearance.customCSSPath);
 const zoom = ref<number>(appearance.zoom);
@@ -81,6 +82,7 @@ store.onDidAnyChange(async newState => {
   startMinimized.value = newState.general.startMinimized;
 
   alwaysShowVolumeSlider.value = newState.appearance.alwaysShowVolumeSlider;
+  centeredPlayerControls.value = newState.appearance.centeredPlayerControls;
   customCSSEnabled.value = newState.appearance.customCSSEnabled;
   customCSSPath.value = newState.appearance.customCSSPath;
   zoom.value = newState.appearance.zoom;
@@ -155,6 +157,7 @@ async function settingsChanged() {
   store.set("general.disableHardwareAcceleration", disableHardwareAcceleration.value);
 
   store.set("appearance.alwaysShowVolumeSlider", alwaysShowVolumeSlider.value);
+  store.set("appearance.centeredPlayerControls", centeredPlayerControls.value);
   store.set("appearance.customCSSEnabled", customCSSEnabled.value);
   store.set("appearance.zoom", zoom.value);
   store.set("appearance.trayIconStyle", trayIconStyle.value);
@@ -315,6 +318,7 @@ window.ytmd.handleUpdateDownloaded(() => {
             @clear="removeCustomCSSPath"
           />
           <YTMDSetting v-model="zoom" type="range" max="300" min="30" step="10" name="Zoom" @change="settingsChanged" />
+          <YTMDSetting v-model="centeredPlayerControls" type="checkbox" name="Center player controls" @change="settingsChanged" />
           <YTMDSetting
             v-if="isLinux"
             v-model="trayIconStyle"

--- a/src/renderer/ytmview/preload.ts
+++ b/src/renderer/ytmview/preload.ts
@@ -62,6 +62,44 @@ function createStyleSheet() {
         opacity: 1 !important;
         pointer-events: initial !important;
       }
+
+      ytmusic-player-bar.ytmd-centered-player-controls {
+        display: grid !important;
+        grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+        column-gap: 16px;
+        align-items: center;
+      }
+
+      ytmusic-player-bar.ytmd-centered-player-controls .middle-controls {
+        grid-column: 1;
+        grid-row: 1;
+        justify-self: start;
+        width: 100%;
+        max-width: 420px;
+        min-width: 0;
+        padding-left: 8px;
+      }
+
+      ytmusic-player-bar.ytmd-centered-player-controls .left-controls {
+        grid-column: 2;
+        grid-row: 1;
+        justify-self: center;
+        position: static !important;
+        transform: none !important;
+        width: auto;
+        min-width: max-content;
+      }
+
+      ytmusic-player-bar.ytmd-centered-player-controls .right-controls {
+        grid-column: 3;
+        grid-row: 1;
+        justify-self: end;
+        min-width: 0;
+      }
+
+      ytmusic-player-bar.ytmd-centered-player-controls .middle-controls .content-info-wrapper {
+        min-width: 0;
+      }
       
       .ytmd-player-bar-control.library-button {
         margin-left: 8px;
@@ -172,6 +210,10 @@ async function hideChromecastButton() {
 
 async function hookPlayerApiEvents() {
   (await webFrame.executeJavaScript(hookPlayerApiEventsScript))();
+}
+
+function setCenteredPlayerControls(enabled: boolean) {
+  document.querySelector("ytmusic-app-layout>ytmusic-player-bar")?.classList.toggle("ytmd-centered-player-controls", enabled);
 }
 
 function overrideHistoryButtonDisplay() {
@@ -336,6 +378,8 @@ window.addEventListener("load", async () => {
   if (alwaysShowVolumeSlider) {
     document.querySelector("ytmusic-app-layout>ytmusic-player-bar #volume-slider").classList.add("ytmd-persist-volume-slider");
   }
+
+  setCenteredPlayerControls((await store.get("appearance")).centeredPlayerControls);
 
   ipcRenderer.on("remoteControl:execute", async (_event, command, value) => {
     switch (command) {
@@ -610,6 +654,8 @@ window.addEventListener("load", async () => {
         volumeSlider.classList.remove("ytmd-persist-volume-slider");
       }
     }
+
+    setCenteredPlayerControls(newState.appearance.centeredPlayerControls);
   });
 
   ipcRenderer.on("ytmView:refitPopups", async () => {

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -17,6 +17,7 @@ export type StoreSchema = {
   };
   appearance: {
     alwaysShowVolumeSlider: boolean;
+    centeredPlayerControls: boolean;
     customCSSEnabled: boolean;
     customCSSPath: string | null;
     zoom: number;


### PR DESCRIPTION
## Summary

Adds a new Appearance setting to center the player controls in the YouTube Music player bar.

When enabled, the playback controls are moved to the center of the player bar while the current track information stays on the left.

## Changes

- Adds a new `Center player controls` toggle under Settings > Appearance, after the Zoom setting.
- Persists the option in the app config as `appearance.centeredPlayerControls`.
- Applies the centered layout dynamically when the setting changes.
- Keeps the default player layout unchanged when the option is disabled.

## Testing

- Ran `yarn lint`
- Ran `yarn package`