### PR TITLE
feat: add localization settings

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -27,6 +27,7 @@ import electronSquirrelStartup from "electron-squirrel-startup";
 import MemoryStore from "./memory-store";
 import playerStateStore, { PlayerState, VideoState } from "./player-state-store";
 import { MemoryStoreSchema, StoreSchema, TrayIconStyle } from "../shared/store/schema";
+import { getTranslations, normalizeLanguage } from "../shared/i18n";
 
 import CompanionServer from "./integrations/companion-server";
 import CustomCSS from "./integrations/custom-css";
@@ -276,14 +277,14 @@ if (app.isPackaged && !shouldDisableUpdates() && !YTMD_DISABLE_UPDATES) {
     url: updateFeed
   });
   autoUpdater.on("checking-for-update", () => {
-    if (appLaunchUpdateCheck) memoryStore.set("ytmViewLoadingStatus", "Checking for updates...");
+    if (appLaunchUpdateCheck) memoryStore.set("ytmViewLoadingStatus", getLoadingText().checkingForUpdates);
     if (settingsWindow) settingsWindow.webContents.send("app:checkingForUpdates");
   });
   autoUpdater.on("update-available", () => {
     log.info("Application update available");
     memoryStore.set("appUpdateAvailable", true);
     appUpdateAvailable = true;
-    if (appLaunchUpdateCheck) memoryStore.set("ytmViewLoadingStatus", "Downloading update...");
+    if (appLaunchUpdateCheck) memoryStore.set("ytmViewLoadingStatus", getLoadingText().downloadingUpdate);
     if (settingsWindow) settingsWindow.webContents.send("app:updateAvailable");
   });
   autoUpdater.on("update-not-available", () => {
@@ -332,6 +333,14 @@ function anyShortcutChanged(newState: Readonly<StoreSchema>, oldState: Readonly<
   return false;
 }
 
+function getDefaultLanguage() {
+  return normalizeLanguage(Intl.DateTimeFormat().resolvedOptions().locale);
+}
+
+function getLoadingText() {
+  return getTranslations(store.has("general.language") ? store.get("general.language") : getDefaultLanguage()).app.loading;
+}
+
 // Create the persistent config store
 const store = new Conf<StoreSchema>({
   configName: "config",
@@ -345,6 +354,7 @@ const store = new Conf<StoreSchema>({
     general: {
       disableHardwareAcceleration: false,
       hideToTrayOnClose: false,
+      language: getDefaultLanguage(),
       showNotificationOnSongChange: false,
       startOnBoot: false,
       startMinimized: false
@@ -412,6 +422,9 @@ const store = new Conf<StoreSchema>({
       if (!store.has("appearance.zoom")) {
         store.set("appearance.zoom", 100);
       }
+      if (!store.has("general.language")) {
+        store.set("general.language", getDefaultLanguage());
+      }
     },
     ">=2.0.1": store => {
       if (!store.has("lastfm.scrobblePercent")) {
@@ -425,6 +438,11 @@ const store = new Conf<StoreSchema>({
     }
   }
 });
+
+if (!store.has("general.language")) {
+  store.set("general.language", getDefaultLanguage());
+}
+
 store.onDidAnyChange(async (newState, oldState) => {
   if (settingsWindow !== null) {
     settingsWindow.webContents.send("settings:stateChanged", newState, oldState);
@@ -1019,7 +1037,7 @@ function isPreventedNavOrRedirect(url: URL): boolean {
 const createYTMView = (): void => {
   memoryStore.set("ytmViewLoadTimedout", false);
   memoryStore.set("ytmViewLoading", true);
-  memoryStore.set("ytmViewLoadingStatus", "Initializing...");
+  memoryStore.set("ytmViewLoadingStatus", getLoadingText().initializing);
 
   ytmView = new BrowserView({
     webPreferences: {
@@ -1155,12 +1173,12 @@ const createYTMView = (): void => {
 
   // Loading status event handlers
   ytmView.webContents.on("did-start-loading", () => {
-    memoryStore.set("ytmViewLoadingStatus", "Loading YouTube Music...");
+    memoryStore.set("ytmViewLoadingStatus", getLoadingText().loadingYouTubeMusic);
   });
 
   ytmView.webContents.on("did-stop-loading", () => {
     if (!memoryStore.get("ytmViewLoadingError")) {
-      memoryStore.set("ytmViewLoadingStatus", "Loaded YouTube Music");
+      memoryStore.set("ytmViewLoadingStatus", getLoadingText().loadedYouTubeMusic);
     }
   });
 
@@ -1169,11 +1187,11 @@ const createYTMView = (): void => {
       if (ytmViewLoadTimeout) clearTimeout(ytmViewLoadTimeout);
 
       memoryStore.set("ytmViewLoadingError", true);
-      memoryStore.set("ytmViewLoadingStatus", `Failed to load YouTube Music: ${errorDescription} (${errorCode})`);
+      memoryStore.set("ytmViewLoadingStatus", getLoadingText().failedToLoadYouTubeMusic(errorDescription, errorCode));
     }
   });
 
-  memoryStore.set("ytmViewLoadingStatus", "Initialized");
+  memoryStore.set("ytmViewLoadingStatus", getLoadingText().initialized);
 
   let navigateDefault = true;
 
@@ -1876,7 +1894,7 @@ app.on("ready", async () => {
   log.info("Created main window");
 
   memoryStore.set("ytmViewLoading", true);
-  memoryStore.set("ytmViewLoadingStatus", "Checking for updates...");
+  memoryStore.set("ytmViewLoadingStatus", getLoadingText().checkingForUpdates);
 
   // Check for application updates
   if (app.isPackaged && !shouldDisableUpdates() && !YTMD_DISABLE_UPDATES) {

--- a/src/renderer/components/YTMDSetting.vue
+++ b/src/renderer/components/YTMDSetting.vue
@@ -6,7 +6,7 @@ type ModelValue = {
   file: string;
   range: number;
   custom: never;
-  select: number;
+  select: number | string;
 };
 
 const props = defineProps<{
@@ -24,7 +24,7 @@ const props = defineProps<{
   disabledMessage?: string;
   flexColumn?: boolean;
   beta?: boolean;
-  optionsMap?: { [key: number]: string }; // This is for the select menu
+  optionsMap?: { [key: number | string]: string }; // This is for the select menu
 }>();
 const emit = defineEmits(["update:modelValue", "file-change", "change", "clear"]);
 
@@ -50,7 +50,7 @@ const selectedOption = computed(() => {
 
 // This function should be using ModelValue[T] but because it's bound to @click it doesn't interpret it as correct
 function select(optionKey: string) {
-  value.value = Number.parseInt(optionKey) as ModelValue[T];
+  value.value = (typeof props.modelValue === "number" ? Number.parseInt(optionKey) : optionKey) as ModelValue[T];
   selectOpen.value = false;
   emit("change");
 }
@@ -299,6 +299,7 @@ input[type="range"]::-webkit-slider-thumb {
 
 .select.open {
   border-radius: 4px 4px 0 0;
+  z-index: 10;
 }
 
 .select .selected {
@@ -319,7 +320,7 @@ input[type="range"]::-webkit-slider-thumb {
   position: absolute;
   left: 0;
   right: 0;
-  z-index: 1;
+  z-index: 11;
   border-radius: 0 0 4px 4px;
   width: 100%;
 }

--- a/src/renderer/components/YTMViewLoading.vue
+++ b/src/renderer/components/YTMViewLoading.vue
@@ -1,13 +1,18 @@
 <script setup lang="ts">
-import { onBeforeMount, ref } from "vue";
+import { computed, onBeforeMount, ref } from "vue";
+import { getTranslations } from "~shared/i18n";
+import { Language, StoreSchema } from "~shared/store/schema";
 import logo from "~assets/icons/ytmd.png";
 
 const memoryStore = window.ytmd.memoryStore;
+const store = window.ytmd.store;
 
 const ytmViewLoading = ref<boolean>(await memoryStore.get("ytmViewLoading"));
 const ytmViewLoadingError = ref<boolean>(await memoryStore.get("ytmViewLoadingError"));
 const ytmViewLoadTimedout = ref<boolean>(await memoryStore.get("ytmViewLoadTimedout"));
 const ytmViewLoadingStatus = ref<string>((await memoryStore.get("ytmViewLoadingStatus")) ?? "");
+const language = ref<Language>(((await store.get("general")) as StoreSchema["general"]).language);
+const text = computed(() => getTranslations(language.value).app.loading);
 
 onBeforeMount(async () => {
   ytmViewLoading.value = await memoryStore.get("ytmViewLoading");
@@ -21,6 +26,10 @@ memoryStore.onStateChanged(newState => {
   ytmViewLoadingError.value = newState.ytmViewLoadingError;
   ytmViewLoadTimedout.value = newState.ytmViewLoadTimedout;
   ytmViewLoadingStatus.value = newState.ytmViewLoadingStatus;
+});
+
+store.onDidAnyChange(newState => {
+  language.value = newState.general.language;
 });
 </script>
 
@@ -40,7 +49,7 @@ memoryStore.onStateChanged(newState => {
           <div class="loader-line"></div>
         </div>
         <p :class="{ 'ytmview-loading-status': true, 'error': ytmViewLoadingError }">{{ ytmViewLoadingStatus }}</p>
-        <p v-if="ytmViewLoadTimedout" class="ytmview-loading-timeout">YouTube Music is taking longer than usual to load</p>
+        <p v-if="ytmViewLoadTimedout" class="ytmview-loading-timeout">{{ text.youTubeMusicLoadTimedOut }}</p>
       </div>
       <div v-else class="ytmview-loading"></div>
     </Transition>

--- a/src/renderer/windows/main/preload.ts
+++ b/src/renderer/windows/main/preload.ts
@@ -3,10 +3,12 @@
 
 import { contextBridge, ipcRenderer } from "electron";
 import { WindowsEventArguments } from "~shared/types";
-import { MemoryStoreSchema } from "~shared/store/schema";
+import { MemoryStoreSchema, StoreSchema } from "~shared/store/schema";
 import MemoryStore from "../../store-ipc/memory-store";
+import Store from "../../store-ipc/store";
 
 const memoryStore = new MemoryStore<MemoryStoreSchema>();
+const store = new Store<StoreSchema>();
 
 contextBridge.exposeInMainWorld("ytmd", {
   minimizeWindow: () => ipcRenderer.send("mainWindow:minimize"),
@@ -24,6 +26,12 @@ contextBridge.exposeInMainWorld("ytmd", {
     set: (key: string, value: unknown) => memoryStore.set(key, value),
     get: async (key: keyof MemoryStoreSchema) => await memoryStore.get(key),
     onStateChanged: (callback: (newState: MemoryStoreSchema, oldState: MemoryStoreSchema) => void) => memoryStore.onStateChanged(callback)
+  },
+  store: {
+    set: (key: string, value: unknown) => store.set(key, value),
+    get: async (key: keyof StoreSchema) => await store.get(key),
+    reset: (key: keyof StoreSchema) => store.reset(key),
+    onDidAnyChange: (callback: (newState: StoreSchema, oldState: StoreSchema) => void) => store.onDidAnyChange(callback)
   },
   restartApplicationForUpdate: () => ipcRenderer.send("app:restartApplicationForUpdate")
 });

--- a/src/renderer/windows/settings/Settings.vue
+++ b/src/renderer/windows/settings/Settings.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import KeybindInput from "../../components/KeybindInput.vue";
 import YTMDSetting from "../../components/YTMDSetting.vue";
-import { StoreSchema, TrayIconStyle } from "~shared/store/schema";
+import { Language, StoreSchema, TrayIconStyle } from "~shared/store/schema";
 import { AuthToken } from "~shared/integrations/companion-server/types";
+import { getTranslations, languageNames } from "~shared/i18n";
 import logo from "~assets/icons/ytmd.png";
 
 declare const YTMD_GIT_COMMIT_HASH: string;
@@ -38,6 +39,7 @@ const lastFM: StoreSchema["lastfm"] = await store.get("lastfm");
 
 const disableHardwareAcceleration = ref<boolean>(general.disableHardwareAcceleration);
 const hideToTrayOnClose = ref<boolean>(general.hideToTrayOnClose);
+const language = ref<Language>(general.language);
 const showNotificationOnSongChange = ref<boolean>(general.showNotificationOnSongChange);
 const startOnBoot = ref<boolean>(general.startOnBoot);
 const startMinimized = ref<boolean>(general.startMinimized);
@@ -73,9 +75,12 @@ const shortcutVolumeDown = ref<string>(shortcuts.volumeDown);
 const lastFMSessionKey = ref<string>(lastFM.sessionKey);
 const scrobblePercent = ref<number>(lastFM.scrobblePercent);
 
+const text = computed(() => getTranslations(language.value).settings);
+
 store.onDidAnyChange(async newState => {
   disableHardwareAcceleration.value = newState.general.disableHardwareAcceleration;
   hideToTrayOnClose.value = newState.general.hideToTrayOnClose;
+  language.value = newState.general.language;
   showNotificationOnSongChange.value = newState.general.showNotificationOnSongChange;
   startOnBoot.value = newState.general.startOnBoot;
   startMinimized.value = newState.general.startMinimized;
@@ -149,6 +154,7 @@ async function memorySettingsChanged() {
 
 async function settingsChanged() {
   store.set("general.hideToTrayOnClose", hideToTrayOnClose.value);
+  store.set("general.language", language.value);
   store.set("general.showNotificationOnSongChange", showNotificationOnSongChange.value);
   store.set("general.startOnBoot", startOnBoot.value);
   store.set("general.startMinimized", startMinimized.value);
@@ -271,23 +277,28 @@ window.ytmd.handleUpdateDownloaded(() => {
   <div class="settings-container">
     <div class="content-container">
       <ul class="sidebar">
-        <li :class="{ active: currentTab === 1 }" @click="changeTab(1)"><span class="material-symbols-outlined">settings_applications</span>General</li>
-        <li :class="{ active: currentTab === 2 }" @click="changeTab(2)"><span class="material-symbols-outlined">brush</span>Appearance</li>
-        <li :class="{ active: currentTab === 3 }" @click="changeTab(3)"><span class="material-symbols-outlined">music_note</span>Playback</li>
-        <li :class="{ active: currentTab === 4 }" @click="changeTab(4)"><span class="material-symbols-outlined">wifi_tethering</span>Integrations</li>
-        <li :class="{ active: currentTab === 5 }" @click="changeTab(5)"><span class="material-symbols-outlined">keyboard</span>Shortcuts</li>
+        <li :class="{ active: currentTab === 1 }" @click="changeTab(1)">
+          <span class="material-symbols-outlined">settings_applications</span>{{ text.tabs.general }}
+        </li>
+        <li :class="{ active: currentTab === 2 }" @click="changeTab(2)"><span class="material-symbols-outlined">brush</span>{{ text.tabs.appearance }}</li>
+        <li :class="{ active: currentTab === 3 }" @click="changeTab(3)"><span class="material-symbols-outlined">music_note</span>{{ text.tabs.playback }}</li>
+        <li :class="{ active: currentTab === 4 }" @click="changeTab(4)">
+          <span class="material-symbols-outlined">wifi_tethering</span>{{ text.tabs.integrations }}
+        </li>
+        <li :class="{ active: currentTab === 5 }" @click="changeTab(5)"><span class="material-symbols-outlined">keyboard</span>{{ text.tabs.shortcuts }}</li>
         <span class="push"></span>
-        <li :class="{ active: currentTab === 99 }" @click="changeTab(99)"><span class="material-symbols-outlined">info</span>About</li>
+        <li :class="{ active: currentTab === 99 }" @click="changeTab(99)"><span class="material-symbols-outlined">info</span>{{ text.tabs.about }}</li>
       </ul>
       <div class="content">
         <div v-if="requiresRestart" class="restart-banner">
-          <p class="message"><span class="material-symbols-outlined">autorenew</span> Restart app to apply changes</p>
-          <button class="restart-button" @click="restartApplication">Restart</button>
+          <p class="message"><span class="material-symbols-outlined">autorenew</span> {{ text.restart.message }}</p>
+          <button class="restart-button" @click="restartApplication">{{ text.restart.button }}</button>
         </div>
         <div v-if="currentTab === 1" class="general-tab">
-          <YTMDSetting v-if="!isDarwin" v-model="hideToTrayOnClose" type="checkbox" name="Hide to tray on close" @change="settingsChanged" />
-          <YTMDSetting v-model="showNotificationOnSongChange" type="checkbox" name="Show notification on song change" @change="settingsChanged" />
-          <YTMDSetting v-model="startOnBoot" type="checkbox" name="Start on boot" @change="settingsChanged" />
+          <YTMDSetting v-model="language" :options-map="languageNames" type="select" :name="text.general.language" @change="settingsChanged" />
+          <YTMDSetting v-if="!isDarwin" v-model="hideToTrayOnClose" type="checkbox" :name="text.general.hideToTrayOnClose" @change="settingsChanged" />
+          <YTMDSetting v-model="showNotificationOnSongChange" type="checkbox" :name="text.general.showNotificationOnSongChange" @change="settingsChanged" />
+          <YTMDSetting v-model="startOnBoot" type="checkbox" :name="text.general.startOnBoot" @change="settingsChanged" />
           <!--<div class="setting">
             <p>Start minimized</p>
             <input v-model="startMinimized" @change="settingsChanged" class="toggle" type="checkbox" />
@@ -296,57 +307,67 @@ window.ytmd.handleUpdateDownloaded(() => {
             v-model="disableHardwareAcceleration"
             type="checkbox"
             restart-required
-            name="Disable hardware acceleration"
+            :name="text.general.disableHardwareAcceleration"
             @change="settingChangedRequiresRestart"
           />
         </div>
 
         <div v-if="currentTab === 2" class="appearance-tab">
-          <YTMDSetting v-model="alwaysShowVolumeSlider" type="checkbox" name="Always show volume slider" @change="settingsChanged" />
-          <YTMDSetting v-model="customCSSEnabled" type="checkbox" name="Custom CSS" @change="settingsChanged" />
+          <YTMDSetting v-model="alwaysShowVolumeSlider" type="checkbox" :name="text.appearance.alwaysShowVolumeSlider" @change="settingsChanged" />
+          <YTMDSetting v-model="customCSSEnabled" type="checkbox" :name="text.appearance.customCSS" @change="settingsChanged" />
           <YTMDSetting
             v-if="customCSSEnabled"
             v-model="customCSSPath"
             type="file"
             indented
             bind-setting="appearance.customCSSPath"
-            name="Custom CSS file path"
+            :name="text.appearance.customCSSFilePath"
             @file-change="settingChangedFile"
             @clear="removeCustomCSSPath"
           />
-          <YTMDSetting v-model="zoom" type="range" max="300" min="30" step="10" name="Zoom" @change="settingsChanged" />
+          <YTMDSetting v-model="zoom" type="range" max="300" min="30" step="10" :name="text.appearance.zoom" @change="settingsChanged" />
           <YTMDSetting
             v-if="isLinux"
             v-model="trayIconStyle"
-            :options-map="{ [TrayIconStyle.Auto]: 'Auto', [TrayIconStyle.White]: 'White', [TrayIconStyle.Black]: 'Black' }"
+            :options-map="{
+              [TrayIconStyle.Auto]: text.appearance.trayIconStyleOptions.auto,
+              [TrayIconStyle.White]: text.appearance.trayIconStyleOptions.white,
+              [TrayIconStyle.Black]: text.appearance.trayIconStyleOptions.black
+            }"
             type="select"
-            name="Tray icon style"
+            :name="text.appearance.trayIconStyle"
             @change="settingsChanged"
           />
         </div>
 
         <div v-if="currentTab === 3" class="playback-tab">
-          <YTMDSetting v-model="continueWhereYouLeftOff" name="Continue where you left off" type="checkbox" @change="settingsChanged" />
+          <YTMDSetting v-model="continueWhereYouLeftOff" :name="text.playback.continueWhereYouLeftOff" type="checkbox" @change="settingsChanged" />
           <YTMDSetting
             v-if="continueWhereYouLeftOff"
             v-model="continueWhereYouLeftOffPaused"
             type="checkbox"
             indented
-            name="Pause on application launch"
+            :name="text.playback.pauseOnApplicationLaunch"
             @change="settingsChanged"
           />
-          <YTMDSetting v-model="progressInTaskbar" type="checkbox" name="Show track progress on taskbar" @change="settingsChanged" />
-          <YTMDSetting v-model="enableSpeakerFill" type="checkbox" restart-required name="Enable speaker fill" @change="settingChangedRequiresRestart" />
-          <YTMDSetting v-model="ratioVolume" type="checkbox" name="Ratio volume" @change="settingsChanged" />
+          <YTMDSetting v-model="progressInTaskbar" type="checkbox" :name="text.playback.showTrackProgressOnTaskbar" @change="settingsChanged" />
+          <YTMDSetting
+            v-model="enableSpeakerFill"
+            type="checkbox"
+            restart-required
+            :name="text.playback.enableSpeakerFill"
+            @change="settingChangedRequiresRestart"
+          />
+          <YTMDSetting v-model="ratioVolume" type="checkbox" :name="text.playback.ratioVolume" @change="settingsChanged" />
         </div>
 
         <div v-if="currentTab === 4" class="integrations-tab">
           <YTMDSetting
             v-model="companionServerEnabled"
             type="checkbox"
-            name="Companion server"
+            :name="text.integrations.companionServer"
             :disabled="!safeStorageAvailable"
-            disabled-message="This integration cannot be enabled due to safeStorage being unavailable"
+            :disabled-message="text.integrations.companionServerDisabled"
             @change="settingsChanged"
           />
           <YTMDSetting
@@ -354,8 +375,8 @@ window.ytmd.handleUpdateDownloaded(() => {
             v-model="companionServerCORSWildcardEnabled"
             type="checkbox"
             indented
-            name="Allow browser communication"
-            description="This setting could be dangerous as it allows any website you visit to communicate with the companion server"
+            :name="text.integrations.allowBrowserCommunication"
+            :description="text.integrations.allowBrowserCommunicationDescription"
             @change="settingsChanged"
           />
           <YTMDSetting
@@ -363,8 +384,8 @@ window.ytmd.handleUpdateDownloaded(() => {
             v-model="companionServerAuthWindowEnabled"
             type="checkbox"
             indented
-            name="Enable companion authorization"
-            description="Automatically disables after the first successful authorization or 5 minutes has passed"
+            :name="text.integrations.enableCompanionAuthorization"
+            :description="text.integrations.enableCompanionAuthorizationDescription"
             @change="memorySettingsChanged"
           />
           <YTMDSetting
@@ -372,15 +393,15 @@ window.ytmd.handleUpdateDownloaded(() => {
             type="custom"
             flex-column
             indented
-            name="Authorized companions"
-            description="This is a list of companions that currently have access to the companion server"
+            :name="text.integrations.authorizedCompanions"
+            :description="text.integrations.authorizedCompanionsDescription"
             @change="settingsChanged"
           >
             <table class="authorized-companions-table">
               <thead>
                 <tr>
-                  <th class="companion">Companion</th>
-                  <th class="version">Version</th>
+                  <th class="companion">{{ text.integrations.companion }}</th>
+                  <th class="version">{{ text.integrations.version }}</th>
                   <th class="controls"></th>
                 </tr>
               </thead>
@@ -399,39 +420,39 @@ window.ytmd.handleUpdateDownloaded(() => {
               </tbody>
             </table>
             <div v-if="companionServerAuthTokens.length === 0" class="no-authorized-companions">
-              <td>No authorized companions</td>
+              <td>{{ text.integrations.noAuthorizedCompanions }}</td>
             </div>
           </YTMDSetting>
-          <YTMDSetting v-model="discordPresenceEnabled" type="checkbox" name="Discord rich presence" @change="settingsChanged" />
+          <YTMDSetting v-model="discordPresenceEnabled" type="checkbox" :name="text.integrations.discordRichPresence" @change="settingsChanged" />
           <div v-if="discordPresenceEnabled && discordPresenceConnectionFailed" class="setting indented">
-            <p class="discord-failure">Discord connection could not be established after 30 attempts</p>
-            <button @click="restartDiscordPresence">Retry</button>
+            <p class="discord-failure">{{ text.integrations.discordConnectionFailed }}</p>
+            <button @click="restartDiscordPresence">{{ text.integrations.retry }}</button>
           </div>
           <YTMDSetting
             v-model="lastFMEnabled"
             type="checkbox"
-            name="Last.fm scrobbling"
+            :name="text.integrations.lastFmScrobbling"
             :disabled="!safeStorageAvailable"
-            disabled-message="This integration cannot be enabled due to safeStorage being unavailable"
+            :disabled-message="text.integrations.lastFmDisabled"
             @change="settingsChanged"
           />
           <div v-if="lastFMEnabled" class="setting indented">
             <div class="name-with-description">
               <p class="description">
-                User is Authenticated:
-                <span v-if="lastFMSessionKey" style="color: #4caf50">Yes</span>
-                <span v-else style="color: #ff1100">No</span>
+                {{ text.integrations.userIsAuthenticated }}
+                <span v-if="lastFMSessionKey" style="color: #4caf50">{{ text.integrations.yes }}</span>
+                <span v-else style="color: #ff1100">{{ text.integrations.no }}</span>
               </p>
             </div>
-            <button v-if="lastFMSessionKey" @click="logoutLastFM">Logout</button>
+            <button v-if="lastFMSessionKey" @click="logoutLastFM">{{ text.integrations.logout }}</button>
           </div>
           <YTMDSetting
             v-if="lastFMEnabled"
             v-model="scrobblePercent"
             class="settings indented"
             type="range"
-            name="Scrobble percent"
-            description="Determines when a song is scrobbled"
+            :name="text.integrations.scrobblePercent"
+            :description="text.integrations.scrobblePercentDescription"
             min="50"
             max="95"
             step="5"
@@ -442,10 +463,8 @@ window.ytmd.handleUpdateDownloaded(() => {
         <div v-if="currentTab === 5" class="shortcuts-tab">
           <div class="setting">
             <p class="shortcut-title">
-              Play/Pause<span
-                v-if="shortcutsPlayPauseRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
+              {{ text.shortcuts.playPause
+              }}<span v-if="shortcutsPlayPauseRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError"
                 >error</span
               >
             </p>
@@ -453,43 +472,29 @@ window.ytmd.handleUpdateDownloaded(() => {
           </div>
           <div class="setting">
             <p class="shortcut-title">
-              Next<span
-                v-if="shortcutsNextRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
-                >error</span
-              >
+              {{ text.shortcuts.next
+              }}<span v-if="shortcutsNextRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError">error</span>
             </p>
             <KeybindInput v-model="shortcutNext" @change="settingsChanged" />
           </div>
           <div class="setting">
             <p class="shortcut-title">
-              Previous<span
-                v-if="shortcutsPreviousRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
-                >error</span
-              >
+              {{ text.shortcuts.previous
+              }}<span v-if="shortcutsPreviousRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError">error</span>
             </p>
             <KeybindInput v-model="shortcutPrevious" @change="settingsChanged" />
           </div>
           <div class="setting">
             <p class="shortcut-title">
-              Thumbs Up<span
-                v-if="shortcutsThumbsUpRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
-                >error</span
-              >
+              {{ text.shortcuts.thumbsUp
+              }}<span v-if="shortcutsThumbsUpRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError">error</span>
             </p>
             <KeybindInput v-model="shortcutThumbsUp" @change="settingsChanged" />
           </div>
           <div class="setting">
             <p class="shortcut-title">
-              Thumbs Down<span
-                v-if="shortcutsThumbsDownRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
+              {{ text.shortcuts.thumbsDown
+              }}<span v-if="shortcutsThumbsDownRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError"
                 >error</span
               >
             </p>
@@ -497,21 +502,15 @@ window.ytmd.handleUpdateDownloaded(() => {
           </div>
           <div class="setting">
             <p class="shortcut-title">
-              Increase Volume<span
-                v-if="shortcutsVolumeUpRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
-                >error</span
-              >
+              {{ text.shortcuts.increaseVolume
+              }}<span v-if="shortcutsVolumeUpRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError">error</span>
             </p>
             <KeybindInput v-model="shortcutVolumeUp" @change="settingsChanged" />
           </div>
           <div class="setting">
             <p class="shortcut-title">
-              Decrease Volume<span
-                v-if="shortcutsVolumeDownRegisterFailed"
-                class="material-symbols-outlined register-error"
-                title="Failed to register keybind. Does another application have this keybind?"
+              {{ text.shortcuts.decreaseVolume
+              }}<span v-if="shortcutsVolumeDownRegisterFailed" class="material-symbols-outlined register-error" :title="text.shortcuts.registerError"
                 >error</span
               >
             </p>
@@ -522,7 +521,7 @@ window.ytmd.handleUpdateDownloaded(() => {
         <div v-if="currentTab === 99" class="about-tab">
           <img class="icon" :src="logo" />
           <h2 class="app-name">YouTube Music Desktop App</h2>
-          <p class="made-by">Made by YTMDesktop Team</p>
+          <p class="made-by">{{ text.about.madeBy }}</p>
           <template v-if="!autoUpdaterDisabled">
             <button
               v-if="!updateDownloaded"
@@ -530,31 +529,31 @@ window.ytmd.handleUpdateDownloaded(() => {
               class="update-check-button"
               @click="checkForUpdates"
             >
-              <span class="material-symbols-outlined">update</span>Check for updates
+              <span class="material-symbols-outlined">update</span>{{ text.about.checkForUpdates }}
             </button>
             <button v-if="updateDownloaded" class="update-button" @click="restartApplicationForUpdate">
-              <span class="material-symbols-outlined">upgrade</span>Restart to update
+              <span class="material-symbols-outlined">upgrade</span>{{ text.about.restartToUpdate }}
             </button>
             <p v-if="checkingForUpdate && !updateAvailable && !updateDownloaded" class="updating">
-              <span class="material-symbols-outlined">progress_activity</span>Checking for updates...
+              <span class="material-symbols-outlined">progress_activity</span>{{ text.about.checkingForUpdates }}
             </p>
             <p v-if="updateAvailable && !updateDownloaded" class="updating">
-              <span class="material-symbols-outlined">progress_activity</span>Downloading update...
+              <span class="material-symbols-outlined">progress_activity</span>{{ text.about.downloadingUpdate }}
             </p>
-            <p v-if="updateNotAvailable" class="no-update">Update not available</p>
+            <p v-if="updateNotAvailable" class="no-update">{{ text.about.updateNotAvailable }}</p>
           </template>
           <template v-if="autoUpdaterDisabled">
-            <button disabled class="update-check-button"><span class="material-symbols-outlined">update</span>Check for updates</button>
-            <p class="no-auto-updater">Auto updater disabled</p>
+            <button disabled class="update-check-button"><span class="material-symbols-outlined">update</span>{{ text.about.checkForUpdates }}</button>
+            <p class="no-auto-updater">{{ text.about.autoUpdaterDisabled }}</p>
           </template>
           <span class="version-info">
-            <p class="version">Version: {{ ytmdVersion }}</p>
-            <p class="branch">Branch: {{ ytmdBranch }}</p>
-            <p class="commit">Commit: {{ ytmdCommitHash }}</p>
+            <p class="version">{{ text.about.version }}: {{ ytmdVersion }}</p>
+            <p class="branch">{{ text.about.branch }}: {{ ytmdBranch }}</p>
+            <p class="commit">{{ text.about.commit }}: {{ ytmdCommitHash }}</p>
           </span>
           <div class="links">
             <a href="https://github.com/ytmdesktop/ytmdesktop" target="_blank">GitHub</a>
-            <a href="https://ytmdesktop.github.io/" target="_blank">Website</a>
+            <a href="https://ytmdesktop.github.io/" target="_blank">{{ text.about.website }}</a>
           </div>
         </div>
       </div>

--- a/src/shared/i18n/index.ts
+++ b/src/shared/i18n/index.ts
@@ -1,0 +1,28 @@
+import { Language } from "../store/schema";
+import enUS from "./locales/en-US";
+import ptBR from "./locales/pt-BR";
+import { TranslationSchema } from "./types";
+
+export const defaultLanguage: Language = "en-US";
+
+export const languageNames: Record<Language, string> = {
+  "en-US": "English",
+  "pt-BR": "Portugues"
+};
+
+export const translations: Record<Language, TranslationSchema> = {
+  "en-US": enUS,
+  "pt-BR": ptBR
+};
+
+export function normalizeLanguage(language: string): Language {
+  if (language.toLowerCase().startsWith("pt")) {
+    return "pt-BR";
+  }
+
+  return defaultLanguage;
+}
+
+export function getTranslations(language: Language): TranslationSchema {
+  return translations[language] ?? translations[defaultLanguage];
+}

--- a/src/shared/i18n/locales/en-US.ts
+++ b/src/shared/i18n/locales/en-US.ts
@@ -1,0 +1,105 @@
+import { TranslationSchema } from "../types";
+
+const enUS: TranslationSchema = {
+  app: {
+    loading: {
+      checkingForUpdates: "Checking for updates...",
+      downloadingUpdate: "Downloading update...",
+      initializing: "Initializing...",
+      loadingYouTubeMusic: "Loading YouTube Music...",
+      loadedYouTubeMusic: "Loaded YouTube Music",
+      initialized: "Initialized",
+      failedToLoadYouTubeMusic: (errorDescription, errorCode) => `Failed to load YouTube Music: ${errorDescription} (${errorCode})`,
+      youTubeMusicLoadTimedOut: "YouTube Music is taking longer than usual to load"
+    }
+  },
+  settings: {
+    tabs: {
+      general: "General",
+      appearance: "Appearance",
+      playback: "Playback",
+      integrations: "Integrations",
+      shortcuts: "Shortcuts",
+      about: "About"
+    },
+    general: {
+      language: "Language",
+      hideToTrayOnClose: "Hide to tray on close",
+      showNotificationOnSongChange: "Show notification on song change",
+      startOnBoot: "Start on boot",
+      disableHardwareAcceleration: "Disable hardware acceleration"
+    },
+    appearance: {
+      alwaysShowVolumeSlider: "Always show volume slider",
+      customCSS: "Custom CSS",
+      customCSSFilePath: "Custom CSS file path",
+      zoom: "Zoom",
+      trayIconStyle: "Tray icon style",
+      trayIconStyleOptions: {
+        auto: "Auto",
+        white: "White",
+        black: "Black"
+      }
+    },
+    playback: {
+      continueWhereYouLeftOff: "Continue where you left off",
+      pauseOnApplicationLaunch: "Pause on application launch",
+      showTrackProgressOnTaskbar: "Show track progress on taskbar",
+      enableSpeakerFill: "Enable speaker fill",
+      ratioVolume: "Ratio volume"
+    },
+    integrations: {
+      companionServer: "Companion server",
+      companionServerDisabled: "This integration cannot be enabled due to safeStorage being unavailable",
+      allowBrowserCommunication: "Allow browser communication",
+      allowBrowserCommunicationDescription: "This setting could be dangerous as it allows any website you visit to communicate with the companion server",
+      enableCompanionAuthorization: "Enable companion authorization",
+      enableCompanionAuthorizationDescription: "Automatically disables after the first successful authorization or 5 minutes has passed",
+      authorizedCompanions: "Authorized companions",
+      authorizedCompanionsDescription: "This is a list of companions that currently have access to the companion server",
+      companion: "Companion",
+      version: "Version",
+      noAuthorizedCompanions: "No authorized companions",
+      discordRichPresence: "Discord rich presence",
+      discordConnectionFailed: "Discord connection could not be established after 30 attempts",
+      retry: "Retry",
+      lastFmScrobbling: "Last.fm scrobbling",
+      lastFmDisabled: "This integration cannot be enabled due to safeStorage being unavailable",
+      userIsAuthenticated: "User is Authenticated:",
+      yes: "Yes",
+      no: "No",
+      logout: "Logout",
+      scrobblePercent: "Scrobble percent",
+      scrobblePercentDescription: "Determines when a song is scrobbled"
+    },
+    shortcuts: {
+      playPause: "Play/Pause",
+      next: "Next",
+      previous: "Previous",
+      thumbsUp: "Thumbs Up",
+      thumbsDown: "Thumbs Down",
+      increaseVolume: "Increase Volume",
+      decreaseVolume: "Decrease Volume",
+      registerError: "Failed to register keybind. Does another application have this keybind?"
+    },
+    about: {
+      madeBy: "Made by YTMDesktop Team",
+      checkForUpdates: "Check for updates",
+      restartToUpdate: "Restart to update",
+      checkingForUpdates: "Checking for updates...",
+      downloadingUpdate: "Downloading update...",
+      updateNotAvailable: "Update not available",
+      autoUpdaterDisabled: "Auto updater disabled",
+      version: "Version",
+      branch: "Branch",
+      commit: "Commit",
+      website: "Website"
+    },
+    restart: {
+      message: "Restart app to apply changes",
+      button: "Restart"
+    }
+  }
+};
+
+export default enUS;

--- a/src/shared/i18n/locales/pt-BR.ts
+++ b/src/shared/i18n/locales/pt-BR.ts
@@ -1,0 +1,105 @@
+import { TranslationSchema } from "../types";
+
+const ptBR: TranslationSchema = {
+  app: {
+    loading: {
+      checkingForUpdates: "Verificando atualizacoes...",
+      downloadingUpdate: "Baixando atualizacao...",
+      initializing: "Inicializando...",
+      loadingYouTubeMusic: "Carregando YouTube Music...",
+      loadedYouTubeMusic: "YouTube Music carregado",
+      initialized: "Inicializado",
+      failedToLoadYouTubeMusic: (errorDescription, errorCode) => `Falha ao carregar o YouTube Music: ${errorDescription} (${errorCode})`,
+      youTubeMusicLoadTimedOut: "O YouTube Music esta demorando mais que o normal para carregar"
+    }
+  },
+  settings: {
+    tabs: {
+      general: "Geral",
+      appearance: "Aparencia",
+      playback: "Reproducao",
+      integrations: "Integracoes",
+      shortcuts: "Atalhos",
+      about: "Sobre"
+    },
+    general: {
+      language: "Idioma",
+      hideToTrayOnClose: "Minimizar para a bandeja ao fechar",
+      showNotificationOnSongChange: "Mostrar notificacao ao trocar de musica",
+      startOnBoot: "Iniciar com o sistema",
+      disableHardwareAcceleration: "Desativar aceleracao de hardware"
+    },
+    appearance: {
+      alwaysShowVolumeSlider: "Sempre mostrar controle de volume",
+      customCSS: "CSS personalizado",
+      customCSSFilePath: "Arquivo CSS personalizado",
+      zoom: "Zoom",
+      trayIconStyle: "Estilo do icone da bandeja",
+      trayIconStyleOptions: {
+        auto: "Automatico",
+        white: "Branco",
+        black: "Preto"
+      }
+    },
+    playback: {
+      continueWhereYouLeftOff: "Continuar de onde parou",
+      pauseOnApplicationLaunch: "Pausar ao iniciar o aplicativo",
+      showTrackProgressOnTaskbar: "Mostrar progresso da faixa na barra de tarefas",
+      enableSpeakerFill: "Ativar preenchimento de alto-falantes",
+      ratioVolume: "Volume em proporcao"
+    },
+    integrations: {
+      companionServer: "Servidor companion",
+      companionServerDisabled: "Esta integracao nao pode ser ativada porque o safeStorage esta indisponivel",
+      allowBrowserCommunication: "Permitir comunicacao com o navegador",
+      allowBrowserCommunicationDescription: "Esta opcao pode ser perigosa porque permite que qualquer site visitado se comunique com o servidor companion",
+      enableCompanionAuthorization: "Ativar autorizacao companion",
+      enableCompanionAuthorizationDescription: "Desativa automaticamente apos a primeira autorizacao bem-sucedida ou depois de 5 minutos",
+      authorizedCompanions: "Companions autorizados",
+      authorizedCompanionsDescription: "Esta e a lista de companions que atualmente tem acesso ao servidor companion",
+      companion: "Companion",
+      version: "Versao",
+      noAuthorizedCompanions: "Nenhum companion autorizado",
+      discordRichPresence: "Presenca rica do Discord",
+      discordConnectionFailed: "Nao foi possivel conectar ao Discord apos 30 tentativas",
+      retry: "Tentar novamente",
+      lastFmScrobbling: "Scrobbling do Last.fm",
+      lastFmDisabled: "Esta integracao nao pode ser ativada porque o safeStorage esta indisponivel",
+      userIsAuthenticated: "Usuario autenticado:",
+      yes: "Sim",
+      no: "Nao",
+      logout: "Sair",
+      scrobblePercent: "Percentual de scrobble",
+      scrobblePercentDescription: "Define quando uma musica sera enviada ao scrobble"
+    },
+    shortcuts: {
+      playPause: "Reproduzir/Pausar",
+      next: "Proxima",
+      previous: "Anterior",
+      thumbsUp: "Gostei",
+      thumbsDown: "Nao gostei",
+      increaseVolume: "Aumentar volume",
+      decreaseVolume: "Diminuir volume",
+      registerError: "Falha ao registrar o atalho. Outro aplicativo ja usa esse atalho?"
+    },
+    about: {
+      madeBy: "Feito pela equipe YTMDesktop",
+      checkForUpdates: "Verificar atualizacoes",
+      restartToUpdate: "Reiniciar para atualizar",
+      checkingForUpdates: "Verificando atualizacoes...",
+      downloadingUpdate: "Baixando atualizacao...",
+      updateNotAvailable: "Atualizacao indisponivel",
+      autoUpdaterDisabled: "Atualizacao automatica desativada",
+      version: "Versao",
+      branch: "Branch",
+      commit: "Commit",
+      website: "Site"
+    },
+    restart: {
+      message: "Reinicie o aplicativo para aplicar as alteracoes",
+      button: "Reiniciar"
+    }
+  }
+};
+
+export default ptBR;

--- a/src/shared/i18n/types.ts
+++ b/src/shared/i18n/types.ts
@@ -1,0 +1,101 @@
+export type TranslationSchema = {
+  app: {
+    loading: {
+      checkingForUpdates: string;
+      downloadingUpdate: string;
+      initializing: string;
+      loadingYouTubeMusic: string;
+      loadedYouTubeMusic: string;
+      initialized: string;
+      failedToLoadYouTubeMusic: (errorDescription: string, errorCode: number) => string;
+      youTubeMusicLoadTimedOut: string;
+    };
+  };
+  settings: {
+    tabs: {
+      general: string;
+      appearance: string;
+      playback: string;
+      integrations: string;
+      shortcuts: string;
+      about: string;
+    };
+    general: {
+      language: string;
+      hideToTrayOnClose: string;
+      showNotificationOnSongChange: string;
+      startOnBoot: string;
+      disableHardwareAcceleration: string;
+    };
+    appearance: {
+      alwaysShowVolumeSlider: string;
+      customCSS: string;
+      customCSSFilePath: string;
+      zoom: string;
+      trayIconStyle: string;
+      trayIconStyleOptions: {
+        auto: string;
+        white: string;
+        black: string;
+      };
+    };
+    playback: {
+      continueWhereYouLeftOff: string;
+      pauseOnApplicationLaunch: string;
+      showTrackProgressOnTaskbar: string;
+      enableSpeakerFill: string;
+      ratioVolume: string;
+    };
+    integrations: {
+      companionServer: string;
+      companionServerDisabled: string;
+      allowBrowserCommunication: string;
+      allowBrowserCommunicationDescription: string;
+      enableCompanionAuthorization: string;
+      enableCompanionAuthorizationDescription: string;
+      authorizedCompanions: string;
+      authorizedCompanionsDescription: string;
+      companion: string;
+      version: string;
+      noAuthorizedCompanions: string;
+      discordRichPresence: string;
+      discordConnectionFailed: string;
+      retry: string;
+      lastFmScrobbling: string;
+      lastFmDisabled: string;
+      userIsAuthenticated: string;
+      yes: string;
+      no: string;
+      logout: string;
+      scrobblePercent: string;
+      scrobblePercentDescription: string;
+    };
+    shortcuts: {
+      playPause: string;
+      next: string;
+      previous: string;
+      thumbsUp: string;
+      thumbsDown: string;
+      increaseVolume: string;
+      decreaseVolume: string;
+      registerError: string;
+    };
+    about: {
+      madeBy: string;
+      checkForUpdates: string;
+      restartToUpdate: string;
+      checkingForUpdates: string;
+      downloadingUpdate: string;
+      updateNotAvailable: string;
+      autoUpdaterDisabled: string;
+      version: string;
+      branch: string;
+      commit: string;
+      website: string;
+    };
+    restart: {
+      message: string;
+      button: string;
+    };
+  };
+};

--- a/src/shared/store/schema.ts
+++ b/src/shared/store/schema.ts
@@ -4,6 +4,8 @@ export enum TrayIconStyle {
   Black = 2
 }
 
+export type Language = "en-US" | "pt-BR";
+
 export type StoreSchema = {
   metadata: {
     version: 1;
@@ -11,6 +13,7 @@ export type StoreSchema = {
   general: {
     disableHardwareAcceleration: boolean;
     hideToTrayOnClose: boolean;
+    language: Language;
     showNotificationOnSongChange: boolean;
     startOnBoot: boolean;
     startMinimized: boolean;


### PR DESCRIPTION
## Summary

Adds a modular localization structure and a language selector for the desktop app UI.

The app now supports English and Portuguese, with English as the default fallback. On first launch, the app uses the system locale to choose Portuguese when the locale starts with `pt`; otherwise it uses English. Users can change the language manually in Settings > General.

## Changes

- Adds a shared i18n structure under `src/shared/i18n`.
- Adds English (`en-US`) and Portuguese (`pt-BR`) translation files.
- Adds `general.language` to the persisted app settings.
- Adds a Language selector in Settings > General.
- Updates Settings UI text to use translations.
- Updates app loading status text to use translations.
- Updates the loading timeout message to use translations.
- Allows select settings to use string values, which is needed for language codes.
- Fixes select dropdown stacking so it appears above following settings controls.

## Testing

- Ran `yarn lint`
- Ran `yarn package`

`yarn lint` passes with the existing unrelated warnings in companion server files.