### PR TITLE
✨ Add tray mini-player popover (macOS)

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -103,6 +103,11 @@ const config: ForgeConfig = {
           entry: "src/renderer/ytmview/preload.ts",
           config: "viteconfig/preload/ytmview.ts",
           target: "preload"
+        },
+        {
+          entry: "src/renderer/windows/miniplayer/preload.ts",
+          config: "viteconfig/preload/miniplayer_window.ts",
+          target: "preload"
         }
       ],
       renderer: [

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -172,6 +172,7 @@ const ytmViewIntegrationScripts: { [name: string]: { [name: string]: string } } 
 
 let mainWindow: BrowserWindow = null;
 let settingsWindow: BrowserWindow = null;
+let playerWindow: BrowserWindow = null;
 let ytmView: BrowserView = null;
 let tray: Tray = null;
 let trayContextMenu = null;
@@ -614,6 +615,15 @@ function setupTaskbarFeatures() {
     const hasVideo = !!state.videoDetails;
     const isPlaying = state.trackState === VideoState.Playing;
 
+    // macOS: album art tray icon + push state to the popover. Other platforms: native menu.
+    updateTrayImage(state);
+    updateTrayContextMenu();
+
+    // Push live state to the popover only while it's visible (avoids needless IPC on every tick)
+    if (playerWindow && !playerWindow.isDestroyed() && playerWindow.isVisible()) {
+      playerWindow.webContents.send("playerState:changed", state);
+    }
+
     if (process.platform == "win32") {
       const taskbarFlags = [];
       if (!hasVideo) {
@@ -695,6 +705,264 @@ function getTrayIconPath() {
 
 function setTrayIcon() {
   tray.setImage(getTrayIconPath());
+}
+
+// Builds a small icon suitable for a tray context menu item
+function getTrayMenuIcon(icon: string) {
+  const image = nativeImage.createFromPath(getControlsIconPath(icon)).resize({ width: 16, height: 16 });
+  // On macOS template images automatically adapt to light/dark menu appearance
+  if (isDarwin) image.setTemplateImage(true);
+  return image;
+}
+
+function truncateForTray(text: string, max = 50) {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+function toggleMainWindowVisibility() {
+  if (!mainWindow) return;
+  if (mainWindow.isVisible()) {
+    mainWindow.hide();
+  } else {
+    mainWindow.show();
+  }
+}
+
+function pickTrayThumbnailUrl(video: PlayerState["videoDetails"] | undefined) {
+  if (!video?.thumbnails?.length) return null;
+  // Prefer a small thumbnail so the download is cheap
+  const sorted = [...video.thumbnails].sort((a, b) => a.width - b.width);
+  const chosen = sorted.find(thumbnail => thumbnail.width >= 48) ?? sorted[sorted.length - 1];
+  return chosen?.url ?? null;
+}
+
+// On macOS the tray icon becomes the current song's album art (falling back to the
+// YTMD logo when nothing is playing). Tracked by URL so we only refetch on song change.
+let currentTrayImageUrl: string | null = null;
+
+async function updateTrayImage(state: PlayerState) {
+  if (!tray || !isDarwin) return;
+
+  const url = pickTrayThumbnailUrl(state?.videoDetails);
+  if (url === currentTrayImageUrl) return;
+  currentTrayImageUrl = url;
+
+  if (!url) {
+    tray.setImage(getTrayIconPath());
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    // The song may have changed while we were fetching; bail if so
+    if (url !== currentTrayImageUrl) return;
+    const image = nativeImage.createFromBuffer(buffer).resize({ width: 18, height: 18 });
+    image.setTemplateImage(false); // show the album art in full color, not a monochrome template
+    tray.setImage(image);
+  } catch (error) {
+    log.error("Failed to load tray album art", error);
+    tray.setImage(getTrayIconPath());
+  }
+}
+
+function buildTrayContextMenu() {
+  // On macOS the left-click popover mini-player carries the now-playing UI, so the
+  // right-click menu only needs the essential window/app actions.
+  if (isDarwin) {
+    return Menu.buildFromTemplate([
+      {
+        label: "Show/Hide Window",
+        type: "normal",
+        click: toggleMainWindowVisibility
+      },
+      {
+        label: "Settings",
+        type: "normal",
+        click: () => createOrShowSettingsWindow()
+      },
+      {
+        type: "separator"
+      },
+      {
+        label: "Quit",
+        type: "normal",
+        click: () => app.quit()
+      }
+    ]);
+  }
+
+  // Windows/Linux keep the full native menu (no popover on these platforms)
+  const state = playerStateStore.getState();
+  const video = state?.videoDetails;
+  const isPlaying = state?.trackState === VideoState.Playing;
+
+  const nowPlaying: MenuItemConstructorOptions[] = video
+    ? [
+        {
+          label: truncateForTray(video.title),
+          type: "normal",
+          click: toggleMainWindowVisibility
+        },
+        ...(video.author
+          ? [
+              {
+                label: truncateForTray(video.author),
+                type: "normal" as const,
+                enabled: false
+              }
+            ]
+          : [])
+      ]
+    : [
+        {
+          label: "Nothing playing",
+          type: "normal",
+          enabled: false
+        }
+      ];
+
+  return Menu.buildFromTemplate([
+    ...nowPlaying,
+    {
+      type: "separator"
+    },
+    {
+      label: "Show/Hide Window",
+      type: "normal",
+      click: toggleMainWindowVisibility
+    },
+    {
+      label: isPlaying ? "Pause" : "Play",
+      type: "normal",
+      icon: getTrayMenuIcon(isPlaying ? "pause-button.png" : "play-button.png"),
+      enabled: !!video,
+      click: () => {
+        if (ytmView) ytmView.webContents.send("remoteControl:execute", "playPause");
+      }
+    },
+    {
+      label: "Previous",
+      type: "normal",
+      icon: getTrayMenuIcon("play-previous-button.png"),
+      enabled: !!video,
+      click: () => {
+        if (ytmView) ytmView.webContents.send("remoteControl:execute", "previous");
+      }
+    },
+    {
+      label: "Next",
+      type: "normal",
+      icon: getTrayMenuIcon("play-next-button.png"),
+      enabled: !!video,
+      click: () => {
+        if (ytmView) ytmView.webContents.send("remoteControl:execute", "next");
+      }
+    },
+    {
+      type: "separator"
+    },
+    {
+      label: "Quit",
+      type: "normal",
+      click: () => {
+        app.quit();
+      }
+    }
+  ]);
+}
+
+// Tracks the last rendered tray menu content so we can skip rebuilds on frequent
+// player state changes (e.g. video progress ticks) that don't affect what's shown.
+// Windows/Linux only — macOS uses the popover for now-playing and a static right-click menu.
+let lastTrayMenuSignature: string | null = null;
+
+function updateTrayContextMenu() {
+  if (!tray || isDarwin) return;
+
+  const state = playerStateStore.getState();
+  const video = state?.videoDetails;
+  const signature = `${video?.title ?? ""} ${video?.author ?? ""} ${state?.trackState ?? ""}`;
+  if (signature === lastTrayMenuSignature) return;
+  lastTrayMenuSignature = signature;
+
+  trayContextMenu = buildTrayContextMenu();
+  tray.setContextMenu(trayContextMenu);
+}
+
+// The tray mini-player popover (macOS only). Created once and shown/hidden on tray click.
+function createPlayerPopover() {
+  if (playerWindow) return;
+
+  playerWindow = new BrowserWindow({
+    width: 300,
+    height: 470,
+    show: false,
+    frame: false,
+    transparent: true,
+    resizable: false,
+    movable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    hasShadow: true,
+    roundedCorners: true,
+    vibrancy: "popover",
+    visualEffectState: "active",
+    webPreferences: {
+      sandbox: true,
+      contextIsolation: true,
+      preload: path.join(__dirname, `../renderer/windows/miniplayer/preload.js`),
+      devTools: store.get("developer.enableDevTools")
+    }
+  });
+
+  // Float the popover above fullscreen apps and on the active space, like a menu bar extra
+  playerWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+
+  if (ALL_WINDOWS_VITE_DEV_SERVER_URL) playerWindow.loadURL(ALL_WINDOWS_VITE_DEV_SERVER_URL + "/windows/miniplayer/index.html");
+  else playerWindow.loadFile(path.join(__dirname, `../renderer/windows/miniplayer/index.html`));
+
+  // Auto-hide when the user clicks away, but not while DevTools are open (dev convenience)
+  playerWindow.on("blur", () => {
+    if (applicationQuitting || !playerWindow || playerWindow.isDestroyed()) return;
+    if (!playerWindow.webContents.isDevToolsOpened()) playerWindow.hide();
+  });
+}
+
+// Position the popover centered under the tray icon, clamped to the display work area
+function positionPlayerPopover() {
+  if (!tray || !playerWindow) return;
+
+  const trayBounds = tray.getBounds();
+  const { workArea } = screen.getDisplayMatching(trayBounds);
+  const [width, height] = playerWindow.getSize();
+  const margin = 8;
+
+  let x = Math.round(trayBounds.x + trayBounds.width / 2 - width / 2);
+  let y = Math.round(trayBounds.y + trayBounds.height + 6);
+
+  x = Math.max(workArea.x + margin, Math.min(x, workArea.x + workArea.width - width - margin));
+  y = Math.max(workArea.y + margin, Math.min(y, workArea.y + workArea.height - height - margin));
+
+  playerWindow.setPosition(x, y, false);
+}
+
+function togglePlayerPopover() {
+  if (!playerWindow) createPlayerPopover();
+  if (playerWindow.isVisible()) {
+    playerWindow.hide();
+    return;
+  }
+
+  positionPlayerPopover();
+  // Send the current state right away so the popover never opens blank
+  playerWindow.webContents.send("playerState:changed", playerStateStore.getState());
+  playerWindow.show();
+  playerWindow.focus();
 }
 
 // Shortcut registration
@@ -1529,6 +1797,29 @@ app.on("ready", async () => {
     createOrShowSettingsWindow();
   });
 
+  // Handle tray mini-player popover ipc
+  ipcMain.handle("playerState:request", () => playerStateStore.getState());
+
+  ipcMain.on("miniplayer:command", (event, command: string, value?: unknown) => {
+    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+    if (ytmView) ytmView.webContents.send("remoteControl:execute", command, value);
+  });
+
+  ipcMain.on("miniplayer:openSettings", event => {
+    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+    createOrShowSettingsWindow();
+  });
+
+  ipcMain.on("miniplayer:toggleMainWindow", event => {
+    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+    toggleMainWindowVisibility();
+  });
+
+  ipcMain.on("miniplayer:hide", event => {
+    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+    playerWindow.hide();
+  });
+
   ipcMain.on("settingsWindow:minimize", event => {
     if (settingsWindow !== null) {
       if (event.sender !== settingsWindow.webContents) return;
@@ -1804,71 +2095,28 @@ app.on("ready", async () => {
 
   // Create the tray
   tray = new Tray(getTrayIconPath());
-  trayContextMenu = Menu.buildFromTemplate([
-    {
-      label: "YouTube Music Desktop",
-      type: "normal",
-      enabled: false
-    },
-    {
-      type: "separator"
-    },
-    {
-      label: "Show/Hide Window",
-      type: "normal",
-      click: () => {
-        if (mainWindow) {
-          if (mainWindow.isVisible()) {
-            mainWindow.hide();
-          } else {
-            mainWindow.show();
-          }
+  tray.setToolTip("YouTube Music Desktop");
+
+  if (isDarwin) {
+    // macOS: left-click opens the popover mini-player, right-click shows the menu.
+    // We must NOT call setContextMenu here or it would hijack the left-click.
+    createPlayerPopover();
+    tray.on("click", () => togglePlayerPopover());
+    tray.on("right-click", () => tray.popUpContextMenu(buildTrayContextMenu()));
+  } else {
+    // Windows/Linux: keep the native context menu and click-to-show-window behavior.
+    trayContextMenu = buildTrayContextMenu();
+    tray.setContextMenu(trayContextMenu);
+    tray.on("click", () => {
+      if (mainWindow) {
+        if (mainWindow.isMinimized()) {
+          mainWindow.restore();
+        } else {
+          mainWindow.show();
         }
       }
-    },
-    {
-      label: "Play/Pause",
-      type: "normal",
-      click: () => {
-        ytmView.webContents.send("remoteControl:execute", "playPause");
-      }
-    },
-    {
-      label: "Previous",
-      type: "normal",
-      click: () => {
-        ytmView.webContents.send("remoteControl:execute", "previous");
-      }
-    },
-    {
-      label: "Next",
-      type: "normal",
-      click: () => {
-        ytmView.webContents.send("remoteControl:execute", "next");
-      }
-    },
-    {
-      type: "separator"
-    },
-    {
-      label: "Quit",
-      type: "normal",
-      click: () => {
-        app.quit();
-      }
-    }
-  ]);
-  tray.setToolTip("YouTube Music Desktop");
-  tray.setContextMenu(trayContextMenu);
-  tray.on("click", () => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) {
-        mainWindow.restore();
-      } else {
-        mainWindow.show();
-      }
-    }
-  });
+    });
+  }
 
   log.info("Created tray icon");
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1775,35 +1775,39 @@ app.on("ready", async () => {
     createOrShowSettingsWindow();
   });
 
-  // Handle tray mini-player popover ipc
-  ipcMain.handle("playerState:request", () => playerStateStore.getState());
+  // Handle tray mini-player popover ipc. The popover is macOS-only, so its handlers are
+  // never registered on other platforms (the popover renderer that sends these only loads
+  // on macOS anyway).
+  if (isDarwin) {
+    ipcMain.handle("playerState:request", () => playerStateStore.getState());
 
-  ipcMain.on("miniplayer:command", (event, command: string, value?: unknown) => {
-    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
-    if (ytmView) ytmView.webContents.send("remoteControl:execute", command, value);
-  });
+    ipcMain.on("miniplayer:command", (event, command: string, value?: unknown) => {
+      if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+      if (ytmView) ytmView.webContents.send("remoteControl:execute", command, value);
+    });
 
-  ipcMain.on("miniplayer:openSettings", event => {
-    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
-    createOrShowSettingsWindow();
-  });
+    ipcMain.on("miniplayer:openSettings", event => {
+      if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+      createOrShowSettingsWindow();
+    });
 
-  ipcMain.on("miniplayer:showMainWindow", event => {
-    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
-    playerWindow.hide(); // dismiss the popover before bringing the window up
-    if (mainWindow) {
-      mainWindow.show();
-      mainWindow.focus();
-      // Pull the app (and the Space hosting the main window) to the foreground; without
-      // stealing focus macOS leaves us on the current Space and the window never surfaces.
-      if (isDarwin) app.focus({ steal: true });
-    }
-  });
+    ipcMain.on("miniplayer:showMainWindow", event => {
+      if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+      playerWindow.hide(); // dismiss the popover before bringing the window up
+      if (mainWindow) {
+        mainWindow.show();
+        mainWindow.focus();
+        // Pull the app (and the Space hosting the main window) to the foreground; without
+        // stealing focus macOS leaves us on the current Space and the window never surfaces.
+        app.focus({ steal: true });
+      }
+    });
 
-  ipcMain.on("miniplayer:hide", event => {
-    if (playerWindow === null || event.sender !== playerWindow.webContents) return;
-    playerWindow.hide();
-  });
+    ipcMain.on("miniplayer:hide", event => {
+      if (playerWindow === null || event.sender !== playerWindow.webContents) return;
+      playerWindow.hide();
+    });
+  }
 
   ipcMain.on("settingsWindow:minimize", event => {
     if (settingsWindow !== null) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -615,7 +615,8 @@ function setupTaskbarFeatures() {
     const hasVideo = !!state.videoDetails;
     const isPlaying = state.trackState === VideoState.Playing;
 
-    // macOS pushes state to the popover; other platforms refresh the native menu.
+    // macOS: album art tray icon + push state to the popover. Other platforms: native menu.
+    updateTrayImage(state);
     updateTrayContextMenu();
 
     // Push live state to the popover only while it's visible (avoids needless IPC on every tick)
@@ -725,6 +726,44 @@ function toggleMainWindowVisibility() {
     mainWindow.hide();
   } else {
     mainWindow.show();
+  }
+}
+
+function pickTrayThumbnailUrl(video: PlayerState["videoDetails"] | undefined) {
+  if (!video?.thumbnails?.length) return null;
+  // Prefer a small thumbnail so the download is cheap
+  const sorted = [...video.thumbnails].sort((a, b) => a.width - b.width);
+  const chosen = sorted.find(thumbnail => thumbnail.width >= 48) ?? sorted[sorted.length - 1];
+  return chosen?.url ?? null;
+}
+
+// On macOS the tray icon becomes the current song's album art (falling back to the
+// YTMD logo when nothing is playing). Tracked by URL so we only refetch on song change.
+let currentTrayImageUrl: string | null = null;
+
+async function updateTrayImage(state: PlayerState) {
+  if (!tray || !isDarwin) return;
+
+  const url = pickTrayThumbnailUrl(state?.videoDetails);
+  if (url === currentTrayImageUrl) return;
+  currentTrayImageUrl = url;
+
+  if (!url) {
+    tray.setImage(getTrayIconPath());
+    return;
+  }
+
+  try {
+    const response = await fetch(url);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    // The song may have changed while we were fetching; bail if so
+    if (url !== currentTrayImageUrl) return;
+    const image = nativeImage.createFromBuffer(buffer).resize({ width: 18, height: 18 });
+    image.setTemplateImage(false); // show the album art in full color, not a monochrome template
+    tray.setImage(image);
+  } catch (error) {
+    log.error("Failed to load tray album art", error);
+    tray.setImage(getTrayIconPath());
   }
 }
 
@@ -878,10 +917,7 @@ function createPlayerPopover() {
       sandbox: true,
       contextIsolation: true,
       preload: path.join(__dirname, `../renderer/windows/miniplayer/preload.js`),
-      devTools: store.get("developer.enableDevTools"),
-      // The popover spends most of its life unfocused; without this Chromium throttles its
-      // timers/paint, which stalls the progress ticker and makes the controls feel laggy.
-      backgroundThrottling: false
+      devTools: store.get("developer.enableDevTools")
     }
   });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -615,8 +615,7 @@ function setupTaskbarFeatures() {
     const hasVideo = !!state.videoDetails;
     const isPlaying = state.trackState === VideoState.Playing;
 
-    // macOS: album art tray icon + push state to the popover. Other platforms: native menu.
-    updateTrayImage(state);
+    // macOS pushes state to the popover; other platforms refresh the native menu.
     updateTrayContextMenu();
 
     // Push live state to the popover only while it's visible (avoids needless IPC on every tick)
@@ -726,44 +725,6 @@ function toggleMainWindowVisibility() {
     mainWindow.hide();
   } else {
     mainWindow.show();
-  }
-}
-
-function pickTrayThumbnailUrl(video: PlayerState["videoDetails"] | undefined) {
-  if (!video?.thumbnails?.length) return null;
-  // Prefer a small thumbnail so the download is cheap
-  const sorted = [...video.thumbnails].sort((a, b) => a.width - b.width);
-  const chosen = sorted.find(thumbnail => thumbnail.width >= 48) ?? sorted[sorted.length - 1];
-  return chosen?.url ?? null;
-}
-
-// On macOS the tray icon becomes the current song's album art (falling back to the
-// YTMD logo when nothing is playing). Tracked by URL so we only refetch on song change.
-let currentTrayImageUrl: string | null = null;
-
-async function updateTrayImage(state: PlayerState) {
-  if (!tray || !isDarwin) return;
-
-  const url = pickTrayThumbnailUrl(state?.videoDetails);
-  if (url === currentTrayImageUrl) return;
-  currentTrayImageUrl = url;
-
-  if (!url) {
-    tray.setImage(getTrayIconPath());
-    return;
-  }
-
-  try {
-    const response = await fetch(url);
-    const buffer = Buffer.from(await response.arrayBuffer());
-    // The song may have changed while we were fetching; bail if so
-    if (url !== currentTrayImageUrl) return;
-    const image = nativeImage.createFromBuffer(buffer).resize({ width: 18, height: 18 });
-    image.setTemplateImage(false); // show the album art in full color, not a monochrome template
-    tray.setImage(image);
-  } catch (error) {
-    log.error("Failed to load tray album art", error);
-    tray.setImage(getTrayIconPath());
   }
 }
 
@@ -908,6 +869,7 @@ function createPlayerPopover() {
     fullscreenable: false,
     skipTaskbar: true,
     alwaysOnTop: true,
+    acceptFirstMouse: true, // first click acts on a control instead of just focusing the window
     hasShadow: true,
     roundedCorners: true,
     vibrancy: "popover",
@@ -916,11 +878,14 @@ function createPlayerPopover() {
       sandbox: true,
       contextIsolation: true,
       preload: path.join(__dirname, `../renderer/windows/miniplayer/preload.js`),
-      devTools: store.get("developer.enableDevTools")
+      devTools: store.get("developer.enableDevTools"),
+      // The popover spends most of its life unfocused; without this Chromium throttles its
+      // timers/paint, which stalls the progress ticker and makes the controls feel laggy.
+      backgroundThrottling: false
     }
   });
 
-  // Float the popover above fullscreen apps and on the active space, like a menu bar extra
+  // Float the popover on the active space and over fullscreen apps, like a menu bar extra.
   playerWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
 
   if (ALL_WINDOWS_VITE_DEV_SERVER_URL) playerWindow.loadURL(ALL_WINDOWS_VITE_DEV_SERVER_URL + "/windows/miniplayer/index.html");
@@ -929,7 +894,9 @@ function createPlayerPopover() {
   // Auto-hide when the user clicks away, but not while DevTools are open (dev convenience)
   playerWindow.on("blur", () => {
     if (applicationQuitting || !playerWindow || playerWindow.isDestroyed()) return;
-    if (!playerWindow.webContents.isDevToolsOpened()) playerWindow.hide();
+    if (playerWindow.webContents.isDevToolsOpened()) return;
+    playerWindow.hide();
+    playerPopoverHiddenAt = Date.now();
   });
 }
 
@@ -951,6 +918,9 @@ function positionPlayerPopover() {
   playerWindow.setPosition(x, y, false);
 }
 
+// Timestamp of the last blur-driven hide, used to swallow the tray click that caused it
+let playerPopoverHiddenAt = 0;
+
 function togglePlayerPopover() {
   if (!playerWindow) createPlayerPopover();
   if (playerWindow.isVisible()) {
@@ -958,9 +928,19 @@ function togglePlayerPopover() {
     return;
   }
 
+  // Clicking the tray while the popover is open blurs it, which hides it just before
+  // this handler runs. Without this guard the click would immediately reopen it,
+  // and rapid clicks would thrash show/hide. Treat a click right after a blur-hide
+  // as "leave it closed".
+  if (Date.now() - playerPopoverHiddenAt < 250) return;
+
   positionPlayerPopover();
   // Send the current state right away so the popover never opens blank
   playerWindow.webContents.send("playerState:changed", playerStateStore.getState());
+  // Show it focused: only a key window receives the blur that drives click-away dismissal
+  // (issue: an inactive popover lingered across every Space), and only a focused window
+  // reliably delivers clicks to the controls. It's visibleOnAllWorkspaces, so focusing it
+  // lands on the current Space rather than pulling the main window's Space forward.
   playerWindow.show();
   playerWindow.focus();
 }
@@ -1810,9 +1790,16 @@ app.on("ready", async () => {
     createOrShowSettingsWindow();
   });
 
-  ipcMain.on("miniplayer:toggleMainWindow", event => {
+  ipcMain.on("miniplayer:showMainWindow", event => {
     if (playerWindow === null || event.sender !== playerWindow.webContents) return;
-    toggleMainWindowVisibility();
+    playerWindow.hide(); // dismiss the popover before bringing the window up
+    if (mainWindow) {
+      mainWindow.show();
+      mainWindow.focus();
+      // Pull the app (and the Space hosting the main window) to the foreground; without
+      // stealing focus macOS leaves us on the current Space and the window never surfaces.
+      if (isDarwin) app.focus({ steal: true });
+    }
   });
 
   ipcMain.on("miniplayer:hide", event => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -615,8 +615,8 @@ function setupTaskbarFeatures() {
     const hasVideo = !!state.videoDetails;
     const isPlaying = state.trackState === VideoState.Playing;
 
-    // macOS: album art tray icon + push state to the popover. Other platforms: native menu.
-    updateTrayImage(state);
+    // macOS pushes state to the popover; other platforms refresh the native menu.
+    // The macOS tray icon stays the static YTMD logo (set once at creation).
     updateTrayContextMenu();
 
     // Push live state to the popover only while it's visible (avoids needless IPC on every tick)
@@ -726,44 +726,6 @@ function toggleMainWindowVisibility() {
     mainWindow.hide();
   } else {
     mainWindow.show();
-  }
-}
-
-function pickTrayThumbnailUrl(video: PlayerState["videoDetails"] | undefined) {
-  if (!video?.thumbnails?.length) return null;
-  // Prefer a small thumbnail so the download is cheap
-  const sorted = [...video.thumbnails].sort((a, b) => a.width - b.width);
-  const chosen = sorted.find(thumbnail => thumbnail.width >= 48) ?? sorted[sorted.length - 1];
-  return chosen?.url ?? null;
-}
-
-// On macOS the tray icon becomes the current song's album art (falling back to the
-// YTMD logo when nothing is playing). Tracked by URL so we only refetch on song change.
-let currentTrayImageUrl: string | null = null;
-
-async function updateTrayImage(state: PlayerState) {
-  if (!tray || !isDarwin) return;
-
-  const url = pickTrayThumbnailUrl(state?.videoDetails);
-  if (url === currentTrayImageUrl) return;
-  currentTrayImageUrl = url;
-
-  if (!url) {
-    tray.setImage(getTrayIconPath());
-    return;
-  }
-
-  try {
-    const response = await fetch(url);
-    const buffer = Buffer.from(await response.arrayBuffer());
-    // The song may have changed while we were fetching; bail if so
-    if (url !== currentTrayImageUrl) return;
-    const image = nativeImage.createFromBuffer(buffer).resize({ width: 18, height: 18 });
-    image.setTemplateImage(false); // show the album art in full color, not a monochrome template
-    tray.setImage(image);
-  } catch (error) {
-    log.error("Failed to load tray album art", error);
-    tray.setImage(getTrayIconPath());
   }
 }
 

--- a/src/main/player-state-store/index.ts
+++ b/src/main/player-state-store/index.ts
@@ -1,8 +1,5 @@
 import { EventEmitter } from "events";
 
-// Public player-state types live in ~shared so renderer windows (the tray mini-player)
-// can consume them without importing main-process code. They are re-exported here so
-// existing `import { PlayerState, VideoState } from "./player-state-store"` call sites keep working.
 export * from "../../shared/player-state";
 import { VideoState, RepeatMode, LikeStatus, VideoType, VideoDetails, PlayerQueueItem, PlayerQueue, PlayerState } from "../../shared/player-state";
 

--- a/src/main/player-state-store/index.ts
+++ b/src/main/player-state-store/index.ts
@@ -1,85 +1,10 @@
 import { EventEmitter } from "events";
 
-export enum VideoState {
-  Unknown = -1,
-  Paused = 0,
-  Playing = 1,
-  Buffering = 2
-}
-
-export enum RepeatMode {
-  Unknown = -1,
-  None = 0,
-  All = 1,
-  One = 2
-}
-
-export enum LikeStatus {
-  Unknown = -1,
-  Dislike = 0,
-  Indifferent = 1,
-  Like = 2
-}
-
-export enum VideoType {
-  Unknown = -1,
-  MusicAudio = 0,
-  MusicVideo = 1,
-  MusicUploaded = 2,
-  PodcastEpisode = 3
-}
-
-export type Thumbnail = {
-  height: number;
-  url: string;
-  width: number;
-};
-
-export type VideoDetails = {
-  album: string;
-  albumId: string;
-  author: string;
-  channelId: string;
-  durationSeconds: number;
-  thumbnails: Thumbnail[];
-  title: string;
-  id: string;
-  likeStatus: LikeStatus;
-  videoType: VideoType;
-  isLive: boolean;
-};
-
-export type PlayerQueueItem = {
-  thumbnails: Thumbnail[];
-  title: string;
-  author: string;
-  duration: string;
-  selected: boolean;
-  videoId: string;
-  counterparts: PlayerQueueItem[];
-};
-
-export type PlayerQueue = {
-  automixItems: PlayerQueueItem[];
-  autoplay: boolean;
-  isGenerating: boolean;
-  isInfinite: boolean;
-  items: PlayerQueueItem[];
-  repeatMode: RepeatMode;
-  selectedItemIndex: number;
-};
-
-export type PlayerState = {
-  videoDetails: VideoDetails;
-  playlistId: string;
-  trackState: VideoState;
-  queue: PlayerQueue;
-  videoProgress: number;
-  volume: number;
-  muted: boolean;
-  adPlaying: boolean;
-  hasFullMetadata: boolean;
-};
+// Public player-state types live in ~shared so renderer windows (the tray mini-player)
+// can consume them without importing main-process code. They are re-exported here so
+// existing `import { PlayerState, VideoState } from "./player-state-store"` call sites keep working.
+export * from "../../shared/player-state";
+import { VideoState, RepeatMode, LikeStatus, VideoType, VideoDetails, PlayerQueueItem, PlayerQueue, PlayerState } from "../../shared/player-state";
 
 enum YTMVideoState {
   Unstarted = -1,

--- a/src/renderer/@types/global.d.ts
+++ b/src/renderer/@types/global.d.ts
@@ -47,7 +47,7 @@ declare global {
       onPlayerState(callback: (state: PlayerState) => void): void;
       sendCommand(command: string, value?: unknown): void;
       openSettings(): void;
-      toggleMainWindow(): void;
+      showMainWindow(): void;
       hide(): void;
 
       // App specific

--- a/src/renderer/@types/global.d.ts
+++ b/src/renderer/@types/global.d.ts
@@ -2,6 +2,7 @@ import { WindowsEventArguments } from "~shared/types";
 import Store from "../store-ipc/store";
 import { StoreSchema, MemoryStoreSchema } from "~shared/store/schema";
 import MemoryStore from "../store-ipc/memory-store";
+import { PlayerState } from "~shared/player-state";
 
 declare global {
   interface Window {
@@ -40,6 +41,14 @@ declare global {
       closeWindow(): void;
       handleWindowEvents(callback: (event: Electron.IpcRendererEvent, args: WindowsEventArguments) => void);
       requestWindowState(): void;
+
+      // Mini-player popover specific
+      requestPlayerState(): Promise<PlayerState | null>;
+      onPlayerState(callback: (state: PlayerState) => void): void;
+      sendCommand(command: string, value?: unknown): void;
+      openSettings(): void;
+      toggleMainWindow(): void;
+      hide(): void;
 
       // App specific
       getAppVersion(): Promise<string>;

--- a/src/renderer/windows/miniplayer/Index.vue
+++ b/src/renderer/windows/miniplayer/Index.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import MiniPlayer from "./MiniPlayer.vue";
+</script>
+
+<template>
+  <MiniPlayer />
+</template>

--- a/src/renderer/windows/miniplayer/MiniPlayer.vue
+++ b/src/renderer/windows/miniplayer/MiniPlayer.vue
@@ -7,6 +7,9 @@ const state = ref<PlayerState | null>(null);
 const localProgress = ref(0);
 let ticker: ReturnType<typeof setInterval> | null = null;
 
+// After a user seek, main keeps reporting the pre-seek progress for ~1s until YTM actually
+// jumps. Trusting those stale values snaps the bar backward then forward — the flicker.
+// We hold the bar at the seek target and ignore reports until one lands near it (or we time out).
 const draggingSeek = ref(false);
 let seekTarget: number | null = null;
 let seekDeadline = 0;

--- a/src/renderer/windows/miniplayer/MiniPlayer.vue
+++ b/src/renderer/windows/miniplayer/MiniPlayer.vue
@@ -4,13 +4,9 @@ import { PlayerState, RepeatMode, VideoState } from "~shared/player-state";
 
 const state = ref<PlayerState | null>(null);
 
-// Local progress so the bar animates smoothly between the ~1s updates from main
 const localProgress = ref(0);
 let ticker: ReturnType<typeof setInterval> | null = null;
 
-// After a user seek, main keeps reporting the pre-seek progress for ~1s until YTM actually
-// jumps. Trusting those stale values snaps the bar backward then forward — the flicker.
-// We hold the bar at the seek target and ignore reports until one lands near it (or we time out).
 const draggingSeek = ref(false);
 let seekTarget: number | null = null;
 let seekDeadline = 0;

--- a/src/renderer/windows/miniplayer/MiniPlayer.vue
+++ b/src/renderer/windows/miniplayer/MiniPlayer.vue
@@ -83,8 +83,21 @@ function playPause() {
 function next() {
   if (hasVideo.value) window.ytmd.sendCommand("next");
 }
+// Threshold (seconds) after which Previous restarts the song instead of skipping back
+const RESTART_THRESHOLD_SECONDS = 3;
+
 function previous() {
-  if (hasVideo.value) window.ytmd.sendCommand("previous");
+  if (!hasVideo.value) return;
+  // Match Spotify / YouTube Music: once you're a few seconds in, Previous restarts the
+  // current track; near the start it skips to the previous one. This also gives the
+  // "single click = restart, quick double click = previous" feel without a click timer —
+  // the first press restarts (now at 0s), so a fast second press skips back.
+  if (progress.value > RESTART_THRESHOLD_SECONDS) {
+    localProgress.value = 0; // optimistic, so a fast second press sees us at the start
+    window.ytmd.sendCommand("seekTo", 0);
+  } else {
+    window.ytmd.sendCommand("previous");
+  }
 }
 function shuffle() {
   if (hasVideo.value) window.ytmd.sendCommand("shuffle");
@@ -125,7 +138,7 @@ function toggleMute() {
 }
 
 function openApp() {
-  window.ytmd.toggleMainWindow();
+  window.ytmd.showMainWindow();
 }
 </script>
 
@@ -135,7 +148,7 @@ function openApp() {
     <div class="scrim"></div>
 
     <div class="content">
-      <div class="art" title="Double-click to open YouTube Music" @dblclick="openApp">
+      <div class="art" title="Open YouTube Music" @click="openApp">
         <img v-if="art" :src="art" alt="" />
         <span v-else class="material-symbols-outlined ph">music_note</span>
       </div>

--- a/src/renderer/windows/miniplayer/MiniPlayer.vue
+++ b/src/renderer/windows/miniplayer/MiniPlayer.vue
@@ -1,0 +1,408 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { PlayerState, RepeatMode, VideoState } from "~shared/player-state";
+
+const state = ref<PlayerState | null>(null);
+
+// Local progress so the bar animates smoothly between the ~1s updates from main
+const localProgress = ref(0);
+let ticker: ReturnType<typeof setInterval> | null = null;
+
+function applyState(next: PlayerState | null) {
+  state.value = next;
+  // Resync the smoothly-ticking bar to the authoritative progress from main
+  localProgress.value = next?.videoProgress ?? 0;
+}
+
+onMounted(async () => {
+  applyState(await window.ytmd.requestPlayerState());
+  window.ytmd.onPlayerState(applyState);
+
+  ticker = setInterval(() => {
+    if (isPlaying.value && hasVideo.value) {
+      const max = duration.value || Number.POSITIVE_INFINITY;
+      localProgress.value = Math.min(localProgress.value + 0.25, max);
+    }
+  }, 250);
+});
+
+onUnmounted(() => {
+  if (ticker) clearInterval(ticker);
+});
+
+const video = computed(() => state.value?.videoDetails ?? null);
+const hasVideo = computed(() => !!video.value);
+const adPlaying = computed(() => !!state.value?.adPlaying);
+const isPlaying = computed(() => state.value?.trackState === VideoState.Playing);
+
+const title = computed(() => (adPlaying.value ? "Advertisement" : video.value?.title || "Nothing playing"));
+const artist = computed(() => (adPlaying.value ? "" : video.value?.author || ""));
+const subtitle = computed(() => (hasVideo.value ? artist.value : "Open YouTube Music to start playing"));
+
+const art = computed(() => {
+  const thumbs = video.value?.thumbnails;
+  if (!thumbs?.length) return null;
+  return [...thumbs].sort((a, b) => b.width - a.width)[0]?.url ?? null; // highest resolution
+});
+
+const duration = computed(() => video.value?.durationSeconds ?? 0);
+const progress = computed(() => Math.min(localProgress.value, duration.value || localProgress.value));
+const progressPct = computed(() => (duration.value ? Math.min(100, (progress.value / duration.value) * 100) : 0));
+
+const muted = computed(() => !!state.value?.muted);
+const volume = ref(100);
+const draggingVolume = ref(false);
+watch(
+  () => state.value?.volume,
+  v => {
+    if (!draggingVolume.value && typeof v === "number") volume.value = v;
+  }
+);
+const volumeDisplay = computed(() => (muted.value ? 0 : volume.value));
+
+const repeatMode = computed(() => state.value?.queue?.repeatMode ?? RepeatMode.None);
+const repeatActive = computed(() => repeatMode.value === RepeatMode.All || repeatMode.value === RepeatMode.One);
+const repeatIcon = computed(() => (repeatMode.value === RepeatMode.One ? "repeat_one" : "repeat"));
+
+const volumeIcon = computed(() => {
+  if (muted.value || volume.value === 0) return "volume_off";
+  if (volume.value < 50) return "volume_down";
+  return "volume_up";
+});
+
+function fmt(seconds: number) {
+  if (!isFinite(seconds) || seconds < 0) seconds = 0;
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function playPause() {
+  if (hasVideo.value) window.ytmd.sendCommand("playPause");
+}
+function next() {
+  if (hasVideo.value) window.ytmd.sendCommand("next");
+}
+function previous() {
+  if (hasVideo.value) window.ytmd.sendCommand("previous");
+}
+function shuffle() {
+  if (hasVideo.value) window.ytmd.sendCommand("shuffle");
+}
+
+function cycleRepeat() {
+  if (!hasVideo.value) return;
+  // None -> All -> One -> None
+  const nextMode: Record<number, string> = {
+    [RepeatMode.None]: "ALL",
+    [RepeatMode.All]: "ONE",
+    [RepeatMode.One]: "NONE"
+  };
+  window.ytmd.sendCommand("repeatMode", nextMode[repeatMode.value] ?? "ALL");
+}
+
+function onSeekInput(e: Event) {
+  localProgress.value = Number((e.target as HTMLInputElement).value);
+}
+function onSeekChange(e: Event) {
+  const secs = Number((e.target as HTMLInputElement).value);
+  localProgress.value = secs;
+  window.ytmd.sendCommand("seekTo", secs);
+}
+
+function onVolumeInput(e: Event) {
+  draggingVolume.value = true;
+  volume.value = Number((e.target as HTMLInputElement).value);
+}
+function onVolumeChange(e: Event) {
+  const v = Number((e.target as HTMLInputElement).value);
+  volume.value = v;
+  window.ytmd.sendCommand("setVolume", v);
+  draggingVolume.value = false;
+}
+function toggleMute() {
+  if (hasVideo.value) window.ytmd.sendCommand(muted.value ? "unmute" : "mute");
+}
+
+function openApp() {
+  window.ytmd.toggleMainWindow();
+}
+</script>
+
+<template>
+  <div class="mini" :class="{ idle: !hasVideo }">
+    <div class="backdrop" :style="art ? { backgroundImage: `url(${art})` } : undefined"></div>
+    <div class="scrim"></div>
+
+    <div class="content">
+      <div class="art" title="Double-click to open YouTube Music" @dblclick="openApp">
+        <img v-if="art" :src="art" alt="" />
+        <span v-else class="material-symbols-outlined ph">music_note</span>
+      </div>
+
+      <div class="meta">
+        <div class="title" :title="title">{{ title }}</div>
+        <div class="artist" :title="subtitle">{{ subtitle }}</div>
+      </div>
+
+      <div class="seek">
+        <input
+          class="range"
+          type="range"
+          min="0"
+          :max="Math.max(duration, 1)"
+          step="1"
+          :value="progress"
+          :disabled="!hasVideo || adPlaying"
+          :style="{ '--pct': progressPct + '%' }"
+          @input="onSeekInput"
+          @change="onSeekChange"
+        />
+        <div class="times">
+          <span>{{ fmt(progress) }}</span>
+          <span>{{ fmt(duration) }}</span>
+        </div>
+      </div>
+
+      <div class="controls">
+        <button class="ctrl" :disabled="!hasVideo" title="Shuffle" @click="shuffle">
+          <span class="material-symbols-outlined">shuffle</span>
+        </button>
+        <button class="ctrl" :disabled="!hasVideo" title="Previous" @click="previous">
+          <span class="material-symbols-outlined">skip_previous</span>
+        </button>
+        <button class="ctrl play" :disabled="!hasVideo" :title="isPlaying ? 'Pause' : 'Play'" @click="playPause">
+          <span class="material-symbols-outlined">{{ isPlaying ? "pause" : "play_arrow" }}</span>
+        </button>
+        <button class="ctrl" :disabled="!hasVideo" title="Next" @click="next">
+          <span class="material-symbols-outlined">skip_next</span>
+        </button>
+        <button class="ctrl" :class="{ active: repeatActive }" :disabled="!hasVideo" title="Repeat" @click="cycleRepeat">
+          <span class="material-symbols-outlined">{{ repeatIcon }}</span>
+        </button>
+      </div>
+
+      <div class="volume">
+        <button class="vol-btn" :disabled="!hasVideo" :title="muted ? 'Unmute' : 'Mute'" @click="toggleMute">
+          <span class="material-symbols-outlined">{{ volumeIcon }}</span>
+        </button>
+        <input
+          class="range vol"
+          type="range"
+          min="0"
+          max="100"
+          step="1"
+          :value="volumeDisplay"
+          :disabled="!hasVideo"
+          :style="{ '--pct': volumeDisplay + '%' }"
+          @input="onVolumeInput"
+          @change="onVolumeChange"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.mini {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  border-radius: 16px;
+  overflow: hidden;
+  user-select: none;
+}
+
+.backdrop {
+  position: absolute;
+  inset: 0;
+  background-color: #1a1a1a;
+  background-size: cover;
+  background-position: center;
+  filter: blur(44px) saturate(1.5) brightness(0.55);
+  transform: scale(1.4);
+}
+
+.scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.2) 0%, rgba(0, 0, 0, 0.55) 60%, rgba(0, 0, 0, 0.78) 100%);
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 20px 22px 22px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.art {
+  width: 196px;
+  height: 196px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.55);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.art img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.art .ph {
+  font-size: 64px;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.meta {
+  width: 100%;
+  text-align: center;
+  min-width: 0;
+}
+.title {
+  font-family: "Open Sans", sans-serif;
+  font-weight: 700;
+  font-size: 16px;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.artist {
+  margin-top: 3px;
+  min-height: 17px; /* reserve the line so layout doesn't shift when there's no artist */
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.62);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.seek {
+  width: 100%;
+}
+.times {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5px;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.6);
+  font-variant-numeric: tabular-nums;
+}
+
+.range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 999px;
+  background: linear-gradient(to right, #ffffff var(--pct, 0%), rgba(255, 255, 255, 0.22) var(--pct, 0%));
+  cursor: pointer;
+  outline: none;
+}
+.range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.range:hover::-webkit-slider-thumb {
+  opacity: 1;
+}
+.range:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+.ctrl {
+  -webkit-app-region: no-drag;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.92);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    transform 0.12s ease,
+    color 0.12s ease;
+}
+.ctrl .material-symbols-outlined {
+  font-size: 26px;
+}
+.ctrl:hover:not(:disabled) {
+  background-color: rgba(255, 255, 255, 0.14);
+}
+.ctrl:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.ctrl.active {
+  color: #ff5b5b;
+}
+.ctrl.play {
+  width: 58px;
+  height: 58px;
+  background: #ffffff;
+  color: #111111;
+}
+.ctrl.play .material-symbols-outlined {
+  font-size: 34px;
+  font-variation-settings: "FILL" 1;
+}
+.ctrl.play:hover:not(:disabled) {
+  background: #ffffff;
+  transform: scale(1.05);
+}
+
+.volume {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.vol-btn {
+  -webkit-app-region: no-drag;
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.82);
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  flex: none;
+}
+.vol-btn .material-symbols-outlined {
+  font-size: 20px;
+}
+.vol-btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+.range.vol {
+  flex: 1;
+}
+</style>

--- a/src/renderer/windows/miniplayer/MiniPlayer.vue
+++ b/src/renderer/windows/miniplayer/MiniPlayer.vue
@@ -18,9 +18,7 @@ let seekDeadline = 0;
 function applyState(next: PlayerState | null) {
   state.value = next;
   const incoming = next?.videoProgress ?? 0;
-  // Don't let an authoritative update fight the thumb the user is dragging
   if (draggingSeek.value) return;
-  // Keep showing the seek target until main confirms a value near it (or the failsafe expires)
   if (seekTarget !== null && Math.abs(incoming - seekTarget) > 1.5 && Date.now() < seekDeadline) return;
   seekTarget = null;
   localProgress.value = incoming;
@@ -134,7 +132,6 @@ function onSeekChange(e: Event) {
   const secs = Number((e.target as HTMLInputElement).value);
   localProgress.value = secs;
   draggingSeek.value = false;
-  // Hold the bar at this target until main reports a matching position (failsafe: 2s)
   seekTarget = secs;
   seekDeadline = Date.now() + 2000;
   window.ytmd.sendCommand("seekTo", secs);
@@ -308,7 +305,7 @@ function openApp() {
 }
 .artist {
   margin-top: 3px;
-  min-height: 17px; /* reserve the line so layout doesn't shift when there's no artist */
+  min-height: 17px;
   font-size: 13px;
   color: rgba(255, 255, 255, 0.62);
   white-space: nowrap;

--- a/src/renderer/windows/miniplayer/MiniPlayer.vue
+++ b/src/renderer/windows/miniplayer/MiniPlayer.vue
@@ -8,10 +8,22 @@ const state = ref<PlayerState | null>(null);
 const localProgress = ref(0);
 let ticker: ReturnType<typeof setInterval> | null = null;
 
+// After a user seek, main keeps reporting the pre-seek progress for ~1s until YTM actually
+// jumps. Trusting those stale values snaps the bar backward then forward — the flicker.
+// We hold the bar at the seek target and ignore reports until one lands near it (or we time out).
+const draggingSeek = ref(false);
+let seekTarget: number | null = null;
+let seekDeadline = 0;
+
 function applyState(next: PlayerState | null) {
   state.value = next;
-  // Resync the smoothly-ticking bar to the authoritative progress from main
-  localProgress.value = next?.videoProgress ?? 0;
+  const incoming = next?.videoProgress ?? 0;
+  // Don't let an authoritative update fight the thumb the user is dragging
+  if (draggingSeek.value) return;
+  // Keep showing the seek target until main confirms a value near it (or the failsafe expires)
+  if (seekTarget !== null && Math.abs(incoming - seekTarget) > 1.5 && Date.now() < seekDeadline) return;
+  seekTarget = null;
+  localProgress.value = incoming;
 }
 
 onMounted(async () => {
@@ -19,7 +31,7 @@ onMounted(async () => {
   window.ytmd.onPlayerState(applyState);
 
   ticker = setInterval(() => {
-    if (isPlaying.value && hasVideo.value) {
+    if (isPlaying.value && hasVideo.value && !draggingSeek.value) {
       const max = duration.value || Number.POSITIVE_INFINITY;
       localProgress.value = Math.min(localProgress.value + 0.25, max);
     }
@@ -115,11 +127,16 @@ function cycleRepeat() {
 }
 
 function onSeekInput(e: Event) {
+  draggingSeek.value = true;
   localProgress.value = Number((e.target as HTMLInputElement).value);
 }
 function onSeekChange(e: Event) {
   const secs = Number((e.target as HTMLInputElement).value);
   localProgress.value = secs;
+  draggingSeek.value = false;
+  // Hold the bar at this target until main reports a matching position (failsafe: 2s)
+  seekTarget = secs;
+  seekDeadline = Date.now() + 2000;
   window.ytmd.sendCommand("seekTo", secs);
 }
 

--- a/src/renderer/windows/miniplayer/index.html
+++ b/src/renderer/windows/miniplayer/index.html
@@ -7,7 +7,6 @@
       :root {
         color-scheme: dark;
       }
-      /* Transparent so the frameless popover can show rounded corners / vibrancy */
       html,
       body,
       #app {

--- a/src/renderer/windows/miniplayer/index.html
+++ b/src/renderer/windows/miniplayer/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>YouTube Music Desktop App - Mini Player</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      /* Transparent so the frameless popover can show rounded corners / vibrancy */
+      html,
+      body,
+      #app {
+        background: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./renderer.ts"></script>
+  </body>
+</html>

--- a/src/renderer/windows/miniplayer/preload.ts
+++ b/src/renderer/windows/miniplayer/preload.ts
@@ -1,0 +1,16 @@
+// Preload for the tray mini-player popover. Exposes a small, typed surface for reading
+// live player state and sending playback commands (forwarded to the YTM view in main).
+import { contextBridge, ipcRenderer } from "electron";
+import type { PlayerState } from "~shared/player-state";
+
+contextBridge.exposeInMainWorld("ytmd", {
+  // Fetch the current state immediately when the popover opens (never wait for the next tick)
+  requestPlayerState: (): Promise<PlayerState | null> => ipcRenderer.invoke("playerState:request"),
+  // Live updates while the popover is open
+  onPlayerState: (callback: (state: PlayerState) => void) => ipcRenderer.on("playerState:changed", (_event, state: PlayerState) => callback(state)),
+  // Playback commands forwarded to remoteControl:execute on the YTM view
+  sendCommand: (command: string, value?: unknown) => ipcRenderer.send("miniplayer:command", command, value),
+  openSettings: () => ipcRenderer.send("miniplayer:openSettings"),
+  toggleMainWindow: () => ipcRenderer.send("miniplayer:toggleMainWindow"),
+  hide: () => ipcRenderer.send("miniplayer:hide")
+});

--- a/src/renderer/windows/miniplayer/preload.ts
+++ b/src/renderer/windows/miniplayer/preload.ts
@@ -11,6 +11,6 @@ contextBridge.exposeInMainWorld("ytmd", {
   // Playback commands forwarded to remoteControl:execute on the YTM view
   sendCommand: (command: string, value?: unknown) => ipcRenderer.send("miniplayer:command", command, value),
   openSettings: () => ipcRenderer.send("miniplayer:openSettings"),
-  toggleMainWindow: () => ipcRenderer.send("miniplayer:toggleMainWindow"),
+  showMainWindow: () => ipcRenderer.send("miniplayer:showMainWindow"),
   hide: () => ipcRenderer.send("miniplayer:hide")
 });

--- a/src/renderer/windows/miniplayer/renderer.ts
+++ b/src/renderer/windows/miniplayer/renderer.ts
@@ -1,0 +1,8 @@
+import "material-symbols/outlined.css";
+import "~assets/app.css";
+
+import { createApp } from "vue";
+import App from "./Index.vue";
+
+const app = createApp(App);
+app.mount("#app");

--- a/src/shared/player-state.ts
+++ b/src/shared/player-state.ts
@@ -1,0 +1,84 @@
+// Public player-state types shared between the main process (player-state-store)
+// and renderer windows (e.g. the tray mini-player popover). Keeping them here avoids
+// the renderer reaching into main-process code and keeps a single source of truth.
+
+export enum VideoState {
+  Unknown = -1,
+  Paused = 0,
+  Playing = 1,
+  Buffering = 2
+}
+
+export enum RepeatMode {
+  Unknown = -1,
+  None = 0,
+  All = 1,
+  One = 2
+}
+
+export enum LikeStatus {
+  Unknown = -1,
+  Dislike = 0,
+  Indifferent = 1,
+  Like = 2
+}
+
+export enum VideoType {
+  Unknown = -1,
+  MusicAudio = 0,
+  MusicVideo = 1,
+  MusicUploaded = 2,
+  PodcastEpisode = 3
+}
+
+export type Thumbnail = {
+  height: number;
+  url: string;
+  width: number;
+};
+
+export type VideoDetails = {
+  album: string;
+  albumId: string;
+  author: string;
+  channelId: string;
+  durationSeconds: number;
+  thumbnails: Thumbnail[];
+  title: string;
+  id: string;
+  likeStatus: LikeStatus;
+  videoType: VideoType;
+  isLive: boolean;
+};
+
+export type PlayerQueueItem = {
+  thumbnails: Thumbnail[];
+  title: string;
+  author: string;
+  duration: string;
+  selected: boolean;
+  videoId: string;
+  counterparts: PlayerQueueItem[];
+};
+
+export type PlayerQueue = {
+  automixItems: PlayerQueueItem[];
+  autoplay: boolean;
+  isGenerating: boolean;
+  isInfinite: boolean;
+  items: PlayerQueueItem[];
+  repeatMode: RepeatMode;
+  selectedItemIndex: number;
+};
+
+export type PlayerState = {
+  videoDetails: VideoDetails;
+  playlistId: string;
+  trackState: VideoState;
+  queue: PlayerQueue;
+  videoProgress: number;
+  volume: number;
+  muted: boolean;
+  adPlaying: boolean;
+  hasFullMetadata: boolean;
+};

--- a/viteconfig/preload/miniplayer_window.ts
+++ b/viteconfig/preload/miniplayer_window.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vite";
+
+// https://vitejs.dev/config
+export default defineConfig({
+  build: {
+    outDir: ".vite/renderer/windows/miniplayer"
+  }
+});

--- a/viteconfig/preload/miniplayer_window.ts
+++ b/viteconfig/preload/miniplayer_window.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from "vite";
 
-// https://vitejs.dev/config
 export default defineConfig({
   build: {
     outDir: ".vite/renderer/windows/miniplayer"

--- a/viteconfig/renderer.ts
+++ b/viteconfig/renderer.ts
@@ -31,7 +31,8 @@ export default defineConfig({
       input: {
         main_window: "src/renderer/windows/main/index.html",
         settings_window: "src/renderer/windows/settings/index.html",
-        authorize_companion_window: "src/renderer/windows/authorize-companion/index.html"
+        authorize_companion_window: "src/renderer/windows/authorize-companion/index.html",
+        miniplayer_window: "src/renderer/windows/miniplayer/index.html"
       },
       output: {
         manualChunks: {


### PR DESCRIPTION
## Summary

Adds a **tray mini-player popover** for macOS. Left-clicking the menu-bar tray icon opens a frameless, vibrancy-backed popover with the now-playing UI; right-click keeps the existing native menu. Windows/Linux are unchanged.


https://github.com/user-attachments/assets/6996eeb3-3a75-4538-9c71-c62fe2061450



## What's included

- Album art, title/artist, and a **seekable progress bar**
- **shuffle / previous / play-pause / next / repeat** controls and a **volume slider**
- Opens focused under the tray icon and **dismisses on click-away**
- Appears on the active Space (and over fullscreen apps), like a menu-bar extra
- Tray icon stays the **static YTMD logo**; right-click menu keeps Show/Hide, Settings, Quit
- Album art links to the full YouTube Music window

## Implementation notes

- New `miniplayer` renderer window (`Index.vue` → `MiniPlayer.vue`, following the existing per-window `Index.vue` convention); a small preload bridges playback commands and player state.
- Public player-state types moved to `~shared/player-state` so renderer windows can consume them without importing main-process code (re-exported from `player-state-store` so existing call sites are unaffected).
- Popover commands are forwarded to the existing `remoteControl:execute` channel on the YTM view — no new control logic.
- Progress bar ticks locally between state pushes and reconciles to main's authoritative progress; a small guard holds the bar at the seek target until main confirms it, avoiding seek flicker.

## Platform scope

**macOS only.** On Windows/Linux the popover window, tray click handlers, and all of its IPC handlers are never created/registered — behavior there is unchanged.

## Testing

Manually verified on macOS: open/focus/click-away dismiss, seek (no flicker), volume, shuffle/repeat, next/previous, and opening the main window from the popover.
