### PR TITLE
feat(titlebar): add button to open current song on YouTube Music

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1529,6 +1529,17 @@ app.on("ready", async () => {
     createOrShowSettingsWindow();
   });
 
+  // Open the current song on music.youtube.com in the default browser
+  ipcMain.on("ytmView:openCurrentSongInBrowser", event => {
+    if (event.sender !== mainWindow.webContents) return;
+
+    const state = playerStateStore.getState();
+    const videoId = state.videoDetails?.id;
+    if (!videoId) return;
+
+    shell.openExternal(`https://music.youtube.com/watch?v=${videoId}`);
+  });
+
   ipcMain.on("settingsWindow:minimize", event => {
     if (settingsWindow !== null) {
       if (event.sender !== settingsWindow.webContents) return;

--- a/src/renderer/@types/global.d.ts
+++ b/src/renderer/@types/global.d.ts
@@ -32,6 +32,7 @@ declare global {
       // YTM view specific
       ytmViewNavigateDefault(): void;
       ytmViewRecreate(): void;
+      openCurrentSongInBrowser(): void;
 
       // Window control
       minimizeWindow(): void;

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -15,6 +15,7 @@ const props = defineProps({
     default: null
   },
   hasHomeButton: Boolean,
+  hasOpenInBrowserButton: Boolean,
   hasSettingsButton: Boolean,
   hasMinimizeButton: Boolean,
   hasMaximizeButton: Boolean,
@@ -32,6 +33,7 @@ const closeWindow = window.ytmd.closeWindow;
 
 const openSettingsWindow = window.ytmd.openSettingsWindow;
 const navigateToDefault = window.ytmd.ytmViewNavigateDefault;
+const openCurrentSongInBrowser = window.ytmd.openCurrentSongInBrowser;
 
 const wcoVisible = ref(window.navigator.windowControlsOverlay.visible);
 const windowMaximized = ref(false);
@@ -97,15 +99,18 @@ if (props.isMainWindow) {
         <button v-if="hasHomeButton" class="app-button" tabindex="2" @click="navigateToDefault">
           <span class="material-symbols-outlined">home</span>
         </button>
-        <button v-if="hasSettingsButton" class="app-button" tabindex="3" @click="openSettingsWindow">
+        <button v-if="hasOpenInBrowserButton" class="app-button" tabindex="3" title="Open current song on YouTube Music" @click="openCurrentSongInBrowser">
+          <span class="material-symbols-outlined">open_in_new</span>
+        </button>
+        <button v-if="hasSettingsButton" class="app-button" tabindex="4" @click="openSettingsWindow">
           <span class="material-symbols-outlined">settings</span>
         </button>
       </div>
       <div v-if="!wcoVisible" class="windows-action-buttons">
-        <button v-if="hasMinimizeButton" class="action-button window-minimize" tabindex="4" @click="minimizeWindow">
+        <button v-if="hasMinimizeButton" class="action-button window-minimize" tabindex="5" @click="minimizeWindow">
           <span class="material-symbols-outlined">remove</span>
         </button>
-        <button v-if="hasMaximizeButton && !windowMaximized" class="action-button window-maximize" tabindex="5" @click="maximizeWindow">
+        <button v-if="hasMaximizeButton && !windowMaximized" class="action-button window-maximize" tabindex="6" @click="maximizeWindow">
           <span class="material-symbols-outlined">square</span>
         </button>
         <button v-if="hasMinimizeButton && windowMaximized" class="action-button window-restore" tabindex="6" @click="restoreWindow">

--- a/src/renderer/windows/main/Index.vue
+++ b/src/renderer/windows/main/Index.vue
@@ -27,7 +27,16 @@ onMounted(() => {
 <template>
   <div ref="keyboardFocusZero" tabindex="0"></div>
   <Suspense>
-    <TitleBar is-main-window has-home-button has-settings-button has-minimize-button has-maximize-button title="YouTube Music Desktop App" :icon-file="logo" />
+    <TitleBar
+      is-main-window
+      has-home-button
+      has-open-in-browser-button
+      has-settings-button
+      has-minimize-button
+      has-maximize-button
+      title="YouTube Music Desktop App"
+      :icon-file="logo"
+    />
   </Suspense>
   <Suspense>
     <YTMViewLoading />

--- a/src/renderer/windows/main/preload.ts
+++ b/src/renderer/windows/main/preload.ts
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld("ytmd", {
   switchFocus: (context: string) => ipcRenderer.send("ytmView:switchFocus", context),
   ytmViewNavigateDefault: () => ipcRenderer.send("ytmView:navigateDefault"),
   ytmViewRecreate: () => ipcRenderer.send("ytmView:recreate"),
+  openCurrentSongInBrowser: () => ipcRenderer.send("ytmView:openCurrentSongInBrowser"),
   memoryStore: {
     set: (key: string, value: unknown) => memoryStore.set(key, value),
     get: async (key: keyof MemoryStoreSchema) => await memoryStore.get(key),


### PR DESCRIPTION
Adds a new button in the main window titlebar that opens the currently playing song on music.youtube.com in the default browser.

- src/main/index.ts: new IPC handler ytmView:openCurrentSongInBrowser reading videoId from playerStateStore and calling shell.openExternal
- src/renderer/windows/main/preload.ts: expose openCurrentSongInBrowser on window.ytmd
- src/renderer/@types/global.d.ts: type declaration for the new API
- src/renderer/components/TitleBar.vue: new hasOpenInBrowserButton prop and button (icon: open_in_new), tabindex sequence adjusted
- src/renderer/windows/main/Index.vue: enable the button on the main window titlebar