### PR TITLE
[codex] reduce companion API rate limit window to 100ms

### DIFF
--- a/src/main/integrations/companion-server/api/v1/index.ts
+++ b/src/main/integrations/companion-server/api/v1/index.ts
@@ -472,7 +472,7 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
         rateLimit: {
           hook: "preHandler",
           max: 1,
-          timeWindow: 1000 * 5,
+          timeWindow: 100,
           keyGenerator: request => {
             return request.authId || request.ip;
           }
@@ -493,8 +493,8 @@ const CompanionServerAPIv1: FastifyPluginCallback<CompanionServerAPIv1Options> =
       config: {
         rateLimit: {
           hook: "preHandler",
-          max: 2,
-          timeWindow: 1000 * 1,
+          max: 1,
+          timeWindow: 100,
           keyGenerator: request => {
             return request.authId || request.ip;
           }


### PR DESCRIPTION
What changed

- reduced the `/command` companion server rate limit from `2 requests / 1 second` to `1 request / 100 ms`
- reduced the `/state` companion server rate limit from `1 request / 5 seconds` to `1 request / 100 ms`

Why

- the current limiter is too restrictive for local integrations that need repeated volume updates or fast command loops
- in live testing this limiter was the direct cause of ignored or delayed commands during fades and rapid control sequences

Impact

- local companion clients can send commands and poll state up to 10 times per second
- this makes smooth fades and tighter external control loops feasible

Root cause

- the companion server had explicit Fastify rate limits on both `/command` and `/state` that were much stricter than expected for a localhost integration

Validation

- confirmed the limiter implementation in `src/main/integrations/companion-server/api/v1/index.ts`
- patched the local clone and pushed the branch to a fork for review